### PR TITLE
Update i18n.md

### DIFF
--- a/developer/architecture/i18n.md
+++ b/developer/architecture/i18n.md
@@ -10,7 +10,7 @@ Reaction uses the [http://i18next.com/](http://i18next.com/) i18n library for tr
 
 _Keys should be camelCase, no spaces, no periods._
 
-The fallback language is EN, so all new translations should go in `packages/reaction-core/private/data/i18n/en.json`, and will fallback to English for other language files if they are missing entries.
+The fallback language is EN, so all new translations should go in `packages/reaction-i18n/private/data/i18n/en.json`, and will fallback to English for other language files if they are missing entries.
 
 **Recommended implementation**
 


### PR DESCRIPTION
I thought all new translations should go in 'reaction-i18n' instead of 'reaction-core'. Please let me know if I got it wrong. Thanks