### PR TITLE
Remove references to Iron Router

### DIFF
--- a/developer/themes/templates.md
+++ b/developer/themes/templates.md
@@ -3,10 +3,6 @@ Reaction Templates are primarily Blaze Templates, but Meteor supports React and 
 
 To learn more about Meteor, Spacebars, and Blaze templates: [http://guide.meteor.com/blaze.html](http://guide.meteor.com/blaze.html)
 
-[Iron Router](https://github.com/EventedMind/iron-router) controllers manages template layout, paths, and permissions.
-
-Review the [Iron Router docs](https://github.com/EventedMind/iron-router/blob/devel/DOCS.md) for background information, then review [packages/reaction-core/common/router.js](https://github.com/reactioncommerce/reaction/blob/development/packages/reaction-core/common/router.js). Here you will be able to see how all the default routes, paths, and template layouts are configured.
-
 ## Extending templates
 Reaction includes the [meteor-template-extension](https://github.com/aldeed/meteor-template-extension) package which provides functionality for extending Meteor templates.
 


### PR DESCRIPTION
Initially replaced it with references to Flow Router, but really there doesn't need to be anything there about routing and the Routing section covers everything you need to know.