### PR TITLE
path correction to example-paymentmthod

### DIFF
--- a/developer/tutorial/creating-a-payment-provider-plugin.md
+++ b/developer/tutorial/creating-a-payment-provider-plugin.md
@@ -27,7 +27,7 @@ plugins are just Meteor modules with some additional configuration.
 ## Getting Started
 
 Start off by copying the `example-paymentmthod` package into the
-`imports/plugins/custom` folder. You will need to add imports to the
+`imports/plugins/included` folder. You will need to add imports to the
 `main.js` file in both the `client` and `server` directories. If you
 wish you can remove imports for the Example Payment Method.
 


### PR DESCRIPTION
The path was pointing to 'imports/plugins/custom/example-paymentmethod' when it should be pointing to 'imports/plugins/included/example-paymentmethod'