### PR TITLE
Update docs to reflect change to priority field default value

### DIFF
--- a/developer/architecture/layout.md
+++ b/developer/architecture/layout.md
@@ -67,7 +67,6 @@ Layouts can work in conjunction with [workflows](/developer/architecture/workflo
     workflow: "coreCartWorkflow",
     container: "checkout-steps-main",
     audience: ["guest", "anonymous"],
-    priority: 1,
     position: "1"
   }, {
     template: "checkoutAddressBook",
@@ -75,7 +74,6 @@ Layouts can work in conjunction with [workflows](/developer/architecture/workflo
     workflow: "coreCartWorkflow",
     container: "checkout-steps-main",
     audience: ["guest", "anonymous"],
-    priority: 2,
     position: "2"
   }, {
     template: "coreCheckoutShipping",
@@ -83,7 +81,6 @@ Layouts can work in conjunction with [workflows](/developer/architecture/workflo
     workflow: "coreCartWorkflow",
     container: "checkout-steps-main",
     audience: ["guest", "anonymous"],
-    priority: 3,
     position: "3"
   }, {
     template: "checkoutReview",
@@ -91,7 +88,6 @@ Layouts can work in conjunction with [workflows](/developer/architecture/workflo
     workflow: "coreCartWorkflow",
     container: "checkout-steps-side",
     audience: ["guest", "anonymous"],
-    priority: 4,
     position: "4"
   }, {
     template: "checkoutPayment",
@@ -99,7 +95,6 @@ Layouts can work in conjunction with [workflows](/developer/architecture/workflo
     workflow: "coreCartWorkflow",
     container: "checkout-steps-side",
     audience: ["guest", "anonymous"],
-    priority: 5,
     position: "5"
   }]
 });

--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -69,12 +69,13 @@ We also need to add our layout to the registry via our `register.js`. We are goi
 ```js
 layout: [{
   layout: "coreLayoutBeesknees",
-  workflow: "coreProductWorkflow",
+  workflow: "coreWorkflow",
   collection: "Products",
   theme: "default",
   enabled: true,
+  priority: 1,
   structure: {
-    template: "products",
+    template: "productsLanding",
     layoutHeader: "layoutHeader",
     layoutFooter: "layoutFooter",
     notFound: "productNotFound",
@@ -103,6 +104,7 @@ Reaction.registerPackage({
     collection: "Products",
     theme: "default",
     enabled: true,
+    priority: 1,
     structure: {
       template: "productsLanding",
       layoutHeader: "layoutHeader",
@@ -119,7 +121,7 @@ Reaction.registerPackage({
 
 You can see we specified several things there. The most important thing was the "layout" record, which refers to the new
 layout template we will create in the next chapter. We also specify which templates we want for the header and footer (we are just keeping the default for now),
-and what's the main template that we render and that's `products`. We also
+and what's the main template that we render and that's `productsLanding`. We also
 specified which template we would use for a "notFound". When we get to the routing and template more of this will make sense.
 
 One important thing to understand is that at any point in time when RC goes to render a route/page it's going to

--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -132,7 +132,7 @@ changing our layout. For example we change point our header or footer to
 a custom template by changing the values for "layoutHeader" or "layoutFooter".
 2. There is a `priority` field on layout objects (with a default value) of `999`. When RC goes to render a route/page
 (as explained above) and more than one layout match is found, this `priority` field is used to determine which one is
- used. Lower values override the default.
+ used. Lower values override the default. [See example](https://github.com/reactioncommerce/reaction-example-plugin/pull/9/files).
 
 Next: [Customizing Templates](/developer/tutorial/plugin-customizing-templates-4)
 

--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -69,13 +69,12 @@ We also need to add our layout to the registry via our `register.js`. We are goi
 ```js
 layout: [{
   layout: "coreLayoutBeesknees",
-  workflow: "coreWorkflow",
+  workflow: "coreProductWorkflow",
   collection: "Products",
   theme: "default",
   enabled: true,
-  priority: 1,
   structure: {
-    template: "productsLanding",
+    template: "products",
     layoutHeader: "layoutHeader",
     layoutFooter: "layoutFooter",
     notFound: "productNotFound",
@@ -104,7 +103,6 @@ Reaction.registerPackage({
     collection: "Products",
     theme: "default",
     enabled: true,
-    priority: 1,
     structure: {
       template: "productsLanding",
       layoutHeader: "layoutHeader",
@@ -121,7 +119,7 @@ Reaction.registerPackage({
 
 You can see we specified several things there. The most important thing was the "layout" record, which refers to the new
 layout template we will create in the next chapter. We also specify which templates we want for the header and footer (we are just keeping the default for now),
-and what's the main template that we render and that's `productsLanding`. We also
+and what's the main template that we render and that's `products`. We also
 specified which template we would use for a "notFound". When we get to the routing and template more of this will make sense.
 
 One important thing to understand is that at any point in time when RC goes to render a route/page it's going to

--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -43,7 +43,7 @@ Reaction Commerce uses one primary layout as the master or default called `coreL
 A common mistake that people make is that they see `Template.dynamic template=layoutHeader` and assume they can change
 the name of the template there. In this context `layoutHeader` is **not** the name of the template but the name of the **variable**
 that contains the template. Changing the name here will break this functionality. It's confusing because the name of the variable
-and the name of the template here are the same so it's an easy mistake to me.
+and the name of the template here are the same so it's an easy mistake to make.
 
 In order to change our default layout, we need add a record to the **registry** for our package. We also need to add a special `defaults.js` that will add some global options.
 

--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -126,9 +126,13 @@ One important thing to understand is that at any point in time when RC goes to r
 determine how to pull the layout record from a key of `layout + workflow`. The `coreWorkflow` is a special case in that it is a workflow with just one step.
 It is essentially the "default" workflow when you hit the home page.
 
-Also note that we have other parts that we could substitute without
+Also note that:
+1. We have other parts that we could substitute without
 changing our layout. For example we change point our header or footer to
 a custom template by changing the values for "layoutHeader" or "layoutFooter".
+2. There is a `priority` field on layout objects (with a default value) of `999`. When RC goes to render a route/page
+(as explained above) and more than one layout match is found, this `priority` field is used to determine which one is
+ used. Lower values override the default.
 
 Next: [Customizing Templates](/developer/tutorial/plugin-customizing-templates-4)
 


### PR DESCRIPTION
Updating the tutorial after changes made in [#2023](https://github.com/reactioncommerce/reaction/pull/2023).  (which is the changing of layout priority default value and using that to allow overriding of templates).

What to review:
* The main comment is in the `plugin-layouts-3.md` file. Check if the description is sufficient.
* Is there any other part of the docs (related to layouts) that needs a similar comment to the one I've added? (so far I've found just that one file)