### PR TITLE
Improve the path description of a file

### DIFF
--- a/developer/configuration.md
+++ b/developer/configuration.md
@@ -2,7 +2,7 @@
 
 Reaction can be configured on startup with a combination of environment variables, `settings/settings.json`, and default data files that provide package and shop pre-configuration.
 
-Reaction uses `/private/settings/reaction.json` for the configuration of Reaction packages and [Meteor.settings](http://docs.meteor.com/#/full/meteor_settings) for initial administrator and server setup.
+Reaction uses `private/settings/reaction.json` for the configuration of Reaction packages and [Meteor.settings](http://docs.meteor.com/#/full/meteor_settings) for initial administrator and server setup.
 
 ## Environment
 


### PR DESCRIPTION
So far, these docs don't use a preceeding forward slash (i.e /) when describing paths relative to the root of a project. This commit fixes a particular path that mistakenly does, because its inconsistency with other paths might signal to a Linux or Mac user that that path is with respect to the root of his/her filesystem.