### PR TITLE
Update Documentation project lead and time

### DIFF
--- a/admin/dashboard.md
+++ b/admin/dashboard.md
@@ -16,6 +16,9 @@ You'll find a selection of dashboard features, broken down into two sections, Ac
 ![Account Permission Screen](/assets/admin-dashboard-account-permission-screen.png)
 
 ## Settings
+
+![](/assets/admin-dashboard-panel.png "Reaction Commerce Dashboard")
+
 - Settings - Configure your shop's name, address, payment methods, and other settings.
 - Catalog - Enable or disable your product catalog view.
 - Localization and i18n - Configure language, timezone, and currency.
@@ -29,5 +32,3 @@ You'll find a selection of dashboard features, broken down into two sections, Ac
 - Email - Manage your mail setup and view email logs.
 - Login services - Enable or disable customer login via social media.
 - Template - Customize your email's messaging and look and feel.
-
-![](/assets/admin-dashboard-page-4.png "Reaction Commerce Dashboard")

--- a/developer/community.md
+++ b/developer/community.md
@@ -30,6 +30,6 @@ Chat channels and meetings are open to all.
 | Components          | @mikemurray @kieckhafer | [reactioncommerce/components](https://gitter.im/reactioncommerce/components)       | Every 2 weeks on Tuesday 3PM Pacific      |
 | Deployment          | @jshimko                | [reactioncommerce/deployment](https://gitter.im/reactioncommerce/deployment)       | Every 2 weeks on Thursday 10AM Eastern    |
 | Design              | @rymorgan               | [reactioncommerce/design](https://gitter.im/reactioncommerce/design)               | Every 2 weeks on Wednesday 3PM Pacific    |
-| Documentation       | @sophiehe               | [reactioncommerce/documentation](https://gitter.im/reactioncommerce/documentation) | Monthly on the Fourth Tuesday 3PM Pacific |
+| Documentation       | @machikoyasuda               | [reactioncommerce/documentation](https://gitter.im/reactioncommerce/documentation) | Monthly on the Fourth Tuesday 3:30PM Pacific |
 | Marketplace         | @spencern               | [reactioncommerce/marketplace](https://gitter.im/reactioncommerce/marketplace)     | Every 2 weeks on Wednesday 7AM Pacific    |
 | Plugins             | @zenweasel @impactmass  | [reactioncommerce/plugins](https://gitter.im/reactioncommerce/plugins)             | Every 2 weeks on Tuesday 1 PM Pacific     |


### PR DESCRIPTION
- Changed lead to @machikoyasuda, from @sophiehe 
- Changed time from 3PM to 3:30PM so the meetings don't overlap with Components' meeting


![screen shot 2017-06-27 at 4 27 06 pm](https://user-images.githubusercontent.com/3673236/27614292-89b845de-5b55-11e7-8786-831adf950bc1.png)
https://docs.reactioncommerce.com/reaction-docs/machikoyasuda-patch-1/community-channels