### PR TITLE
add build tools install instructions for CentOS

### DIFF
--- a/developer/requirements.md
+++ b/developer/requirements.md
@@ -93,6 +93,18 @@ apt-get update
 apt-get install -y --no-install-recommends build-essential bzip2 curl ca-certificates git graphicsmagick python
 ```
 
+```sh
+# CentOS/RHEL
+
+# build tools
+yum groupinstall "Development Tools"
+
+# add "Extra Packages for Enterprise Linux" repository for GraphicsMagick
+yum install epel-release
+
+yum install GraphicsMagick
+```
+
 **Meteor**
 
 ```sh


### PR DESCRIPTION
Tested and confirmed working on CentOS 7.  

To test:

```sh
# hop into a fresh CentOS image
docker run -it --rm centos:7 /bin/bash

# install Reaction dependencies
yum groupinstall "Development Tools"
yum install epel-release
yum install GraphicsMagick nodejs

npm i -g reaction-cli

reaction init

cd reaction 

# because we're currently root inside the container...
export METEOR_ALLOW_SUPERUSER=true

reaction
```