### PR TITLE
add missing label for Community Guidelines so it's not a ghost link

### DIFF
--- a/redoc.json
+++ b/redoc.json
@@ -691,6 +691,7 @@
   }, {
     "class": "guide-nav-item",
     "alias": "guidelines",
+    "label": "Community Guidelines",
     "repo": "reaction-docs",
     "docPath": "guidelines/guidelines.md"
   }, {


### PR DESCRIPTION
## problem

sophie pointed out that above `Code of Conduct`, you can hover and click on a link to the guidelines.. but there is no link text there. i had no idea there was a 👻  link there. 
![image](https://user-images.githubusercontent.com/3673236/28394747-15c859d8-6ca4-11e7-97e7-4a6e3d87cb64.png)

## solved

so i brought it back in `redoc.json`

test here: https://docs.reactioncommerce.com/reaction-docs/community-url-in-toc/intro

![screen shot 2017-07-19 at 5 03 57 pm](https://user-images.githubusercontent.com/3673236/28394772-4d108f00-6ca4-11e7-812f-f2aea06899e0.png)
