### PR TITLE
Fix wrong import in plugin-customizing-templates-4.md

### DIFF
--- a/developer/tutorial/plugin-customizing-templates-4.md
+++ b/developer/tutorial/plugin-customizing-templates-4.md
@@ -20,7 +20,7 @@ To make this template part of the project we need to import it, so we add it to 
 
 ```js
 // client/index.js
-import "./components";
+import "./templates";
 ```
 
 ## client/templates/index.js


### PR DESCRIPTION
On the section **client/index.js** the import points to `./components` but it should say `./templates` in this context.