### PR TITLE
Fix outdated Import

### DIFF
--- a/developer/tutorial/plugin-layouts-3.md
+++ b/developer/tutorial/plugin-layouts-3.md
@@ -18,7 +18,7 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import Blaze from "meteor/gadicc:blaze-react-component";
 import { Template } from "meteor/templating";
-import { registerComponent } from "/imports/plugins/core/layout/lib/components";
+import { registerComponent } from "@reactioncommerce/reaction-components";
 
 class CoreLayoutBeesknees extends Component {
   static propTypes = {


### PR DESCRIPTION
In Reaction 1.5 the imports can point to the reaction package instead of using an absolute path to the plugin.

In this case replace `import { registerComponent } from "/imports/plugins/core/layout/lib/components";` with `import { registerComponent } from "@reactioncommerce/reaction-components";`