### PR TITLE
update platform.md

### DIFF
--- a/developer/deploying/platform.md
+++ b/developer/deploying/platform.md
@@ -1,10 +1,10 @@
 # Reaction Platform
 
-Reaction Commerce offers a managed deployment option, [Reaction Platform](http://getrxn.io/reaction-platform).
+The following documentation is for paid users of [Reaction Platform](getrxn.io/reaction-platform). 
 
 The `reaction-cli` incorporates functionality for any team to deploy Reaction Commerce to multiple environments. [Visit reactioncommerce.com](http://getrxn.io/reaction-platform) to get a demo.
 
-1.  Request invite token
+1.  Get invite token from welcome email or contract
 2.  Register local environment
 3.  Create, add, and publish SSH keys
 4.  Create application environment
@@ -12,7 +12,7 @@ The `reaction-cli` incorporates functionality for any team to deploy Reaction Co
 
 ## Request invite token
 
-As a user of the **Reaction Platform**, you'll receive an email containing a "invite token" from the Reaction Platform API ("Launchdock"). **Launchdock** is the name of our internal  orchestration management platform.
+As a paid user of the **Reaction Platform**, you'll receive an email containing a "invite token" from the Reaction Platform API ("Launchdock"). **Launchdock** is the name of our internal  orchestration management platform.
 
 You will be asked for your invite token when you use the [reaction-cli](http://getrxn.io/reaction-cli) to register your local Reaction environment with the Reaction Platform API.
 

--- a/developer/deploying/platform.md
+++ b/developer/deploying/platform.md
@@ -1,10 +1,10 @@
 # Reaction Platform
 
-Reaction Commerce offers a managed deployment option, the [Reaction Platform](http://getrxn.io/reaction-platform).
+Reaction Commerce offers a managed deployment option, [Reaction Platform](http://getrxn.io/reaction-platform).
 
-The `reaction-cli` incorporates functionality for any team to deploy Reaction Commerce to multiple environments. [Visit reactioncommerce.com](http://getrxn.io/reaction-platform) to get a demo or request an **invite token**.
+The `reaction-cli` incorporates functionality for any team to deploy Reaction Commerce to multiple environments. [Visit reactioncommerce.com](http://getrxn.io/reaction-platform) to get a demo.
 
-1.  [Request invite token](http://getrxn.io/reaction-platform).
+1.  Request invite token
 2.  Register local environment
 3.  Create, add, and publish SSH keys
 4.  Create application environment
@@ -14,7 +14,7 @@ The `reaction-cli` incorporates functionality for any team to deploy Reaction Co
 
 As a user of the **Reaction Platform**, you'll receive an email containing a "invite token" from the Reaction Platform API ("Launchdock"). **Launchdock** is the name of our internal  orchestration management platform.
 
-You will be asked for your [invite token](http://getrxn.io/reaction-platform) when you use the [reaction-cli](http://getrxn.io/reaction-cli) to register your local Reaction environment with the Reaction Platform API.
+You will be asked for your invite token when you use the [reaction-cli](http://getrxn.io/reaction-cli) to register your local Reaction environment with the Reaction Platform API.
 
 ## Register local environment
 


### PR DESCRIPTION
removed links to /hosting LP. Signing up through the Platform page will put users in our sales funnel, then we'll have to qualify these leads before giving them a token, etc. Is there anywhere else we can refer users?