### PR TITLE
document ‘reaction logs’ command

### DIFF
--- a/developer/deploying/platform.md
+++ b/developer/deploying/platform.md
@@ -163,6 +163,7 @@ To get all application logs since your app's last startup:
 
 ```sh
 reaction logs --app <appname>
+reaction logs -a <appname>
 ```
 
 Hint: to get a list of all apps you have access to, run `reaction apps list`

--- a/developer/deploying/platform.md
+++ b/developer/deploying/platform.md
@@ -1,6 +1,6 @@
 # Reaction Platform
 
-The following documentation is for paid users of [Reaction Platform](getrxn.io/reaction-platform). 
+The following documentation is for paid users of [Reaction Platform](getrxn.io/reaction-platform).
 
 The `reaction-cli` incorporates functionality for any team to deploy Reaction Commerce to multiple environments. [Visit reactioncommerce.com](http://getrxn.io/reaction-platform) to get a demo.
 
@@ -156,6 +156,16 @@ reaction deploy --name <appname>
 ```
 
 Expect to receive an email with the completed build status (failed or deployed).
+
+## logs
+
+To get all application logs since your app's last startup:
+
+```sh
+reaction logs --app <appname>
+```
+
+Hint: to get a list of all apps you have access to, run `reaction apps list`
 
 **CI/CD Configuration**
 


### PR DESCRIPTION
To get all application logs since your app's last startup:

```sh
reaction logs --app <appname>
reaction logs -a <appname>
```

For the explanation about why you can't currently tail logs, I'll take the comment from https://github.com/reactioncommerce/launchdock/pull/114#issuecomment-345888875

> Well, I should probably have stated the caveat that this is the MVP for the logs API.  I just wanted to give people a way to debug their deployments as soon as possible.  By default, you get _all_ of the logs since the app last started.  That can be adjusted by line count or "since" time, but I haven't enabled those flags in the CLI yet.  
>
> Tailing _will_ be possible, but it's significantly more complicated for a few reasons.  The main one being because users can potentially have multiple containers running for a single app. So to make sure we get all logs for all containers, Launchdock queries for the logs with a Kubernetes "label" ([docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)) that each pod for a given app has.  That will return logs for all pods containing that label in a single API call.  The tradeoff is you can't tail multiple containers at the same time like that.  You have to specify which pod you want to tail.  That's why people have come up with tools like [this](https://github.com/wercker/stern) and [this](https://github.com/johanhaleby/kubetail) which essentially open multiple calls to the Kubernetes API and merges them into one result.  That said, that's pretty much what I'm going to need to do to make tailing work across multiple containers.  Either that, or I need to add an API for specifying which container you want to tail.  Or both.  (probably both).