### PR TITLE
Update style for import order list

### DIFF
--- a/developer/styleguide.md
+++ b/developer/styleguide.md
@@ -18,12 +18,12 @@ Our rules are similar to [Airbnb JavaScript Style Guide](https://github.com/airb
 - Give methods space
 - Add spaces around brackets
 - 120 character line-length
-- `import` listed in this order:
-    1.React npm packages (`React`, `prop-types`)
-    2.Other npm packages
-    3.Meteor core packages
-    4.Meteor (Atmosphere) packages
-    5.Local app files
+- `import`s should be listed in this order:
+  1. React npm packages (`React`, `prop-types`)
+  2. Other npm packages
+  3. Meteor core packages
+  4. Meteor (Atmosphere) packages
+  5. Local app files
 
 Other Reaction-specific rules are checked using various linting libraries. Find all the rules in the code:
 


### PR DESCRIPTION
Fix the listing of import order to have each item on new line instead of all on the same line.
This improves readability.

![screenshot 2017-12-06 19 29 53](https://user-images.githubusercontent.com/5229321/33678385-dbb70a38-dabb-11e7-97d1-4f8dc41cdf8a.jpg)


