### PR TITLE
#414: add git guide

### DIFF
--- a/developer/git-style-guide.md
+++ b/developer/git-style-guide.md
@@ -1,0 +1,49 @@
+# Git style guide
+
+Git version control is how we work together as a team. Naming branches and writing commit messages helps us keep a easy-to-understand history of the changes in the project.
+
+## Naming Git branches
+
+Create a branch name, with the ID number of the GitHub issue, in the following style:
+`type-###-yourhandle-slug`. Example: `feat-123-impactmass-permissions`, `fix-222-spencern-shopify-hooks`
+
+## Writing commit messages
+
+Make atomic commits in the [Git commit message guidelines from Angular.js](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits), with a `(type):` followed by `subject`.
+
+All of the types:
+- *feat*: A new feature
+- *fix*: A bug fix
+- *docs*: Documentation only changes
+- *style*: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- *refactor*: A code change that neither fixes a bug nor adds a feature
+- *perf*: A code change that improves performance
+- *test*: Adding missing or correcting existing tests
+- *chore*: Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+Note the following styles:
+- Use the imperative, present tense: use "change", not "changed" nor "changes"
+- Do not capitalize first letter
+- No dot (.) at the end
+- Use `BREAKING CHANGES:` to note breaking changes
+
+Examples:
+```
+(feat): add sendEmail() job
+(docs): add doc for sendEmailJob() method
+(refactor): replace Blaze component with React component
+
+BREAKING CHANGES: remove Header Blaze template. To migrate to the React component, use HeaderComponent.
+```
+
+See more [examples from Angular.js](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#heading=h.8sw072iehlhg).
+
+## Making a pull request
+
+Title the pull request (PR) with the ID number of the GitHub issue. Add `WIP` (work in progress) to the beginning of the title to get feedback early on.
+
+Follow the [PR template](https://github.com/reactioncommerce/reaction/blob/master/.github/pull_request_template.md) provided and make sure to add `Closes ###` with the GitHub issue number.
+
+## Wait for a code review
+
+Congrats! You made a pull request. Head to the [Code review process guide](/developer/code-review.md) to see what's next.

--- a/redoc.json
+++ b/redoc.json
@@ -190,7 +190,7 @@
   }, {
     "class": "guide-sub-nav-item",
     "alias": "styleguide",
-    "label": "Style Guide",
+    "label": "Code Style Guide",
     "repo": "reaction-docs",
     "docPath": "developer/styleguide.md"
   }, {

--- a/redoc.json
+++ b/redoc.json
@@ -195,6 +195,12 @@
     "docPath": "developer/styleguide.md"
   }, {
     "class": "guide-sub-nav-item",
+    "alias": "styleguide",
+    "label": "Git Style Guide",
+    "repo": "reaction-docs",
+    "docPath": "developer/git-style-guide.md"
+  },{
+    "class": "guide-sub-nav-item",
     "alias": "react-best-practices",
     "label": "React Best Practices",
     "repo": "reaction-docs",

--- a/redoc.json
+++ b/redoc.json
@@ -195,7 +195,7 @@
     "docPath": "developer/styleguide.md"
   }, {
     "class": "guide-sub-nav-item",
-    "alias": "styleguide",
+    "alias": "git-style-guide",
     "label": "Git Style Guide",
     "repo": "reaction-docs",
     "docPath": "developer/git-style-guide.md"


### PR DESCRIPTION
closes https://github.com/reactioncommerce/reaction-docs/issues/414

re-submitted from https://github.com/reactioncommerce/reaction-docs/pull/345, which i messed up from some hasty rebasing

## what this doc does:

document Git commit message, branch naming style

## what it looks like:

![screen shot 2017-12-08 at 3 09 37 pm](https://user-images.githubusercontent.com/3673236/33788901-decc67d0-dc29-11e7-911f-18028e29f485.png)
https://docs.reactioncommerce.com/reaction-docs/docs-414-machikoyasuda-git-guide/git-style-guide