### PR TITLE
toc: divide up into more categories (#328)

### DIFF
--- a/redoc.json
+++ b/redoc.json
@@ -219,6 +219,18 @@
 			"docPath": "developer/react-best-practices.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "release-process",
+			"label": "Release Guide",
+			"repo": "reaction-docs",
+			"docPath": "developer/testing/release-process.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "reporting-vulnerabilities",
+			"label": "Report Vulnerabilities",
+			"repo": "reaction-docs",
+			"docPath": "developer/testing/vulnerabilities.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "community-channels",
 			"label": "Community",
 			"repo": "reaction-docs",
@@ -670,18 +682,6 @@
 			"label": "CI Builds",
 			"repo": "reaction-docs",
 			"docPath": "developer/testing/ci.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "release-process",
-			"label": "Release Process",
-			"repo": "reaction-docs",
-			"docPath": "developer/testing/release-process.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "reporting-vulnerabilities",
-			"label": "Report Vulnerabilities",
-			"repo": "reaction-docs",
-			"docPath": "developer/testing/vulnerabilities.md"
 		}, {
 			"class": "guide-nav-item",
 			"alias": "deploying",

--- a/redoc.json
+++ b/redoc.json
@@ -51,10 +51,10 @@
 			"docPath": "developer/configuration.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "developer-faq",
-			"label": "Developer FAQs",
+			"alias": "email-api",
+			"label": "Email",
 			"repo": "reaction-docs",
-			"docPath": "developer/developer-faqs.md"
+			"docPath": "developer/core/email.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "styleguide",
@@ -81,32 +81,20 @@
 			"docPath": "developer/contributing.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "developer-faq",
+			"label": "FAQs",
+			"repo": "reaction-docs",
+			"docPath": "developer/developer-faqs.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "community-channels",
 			"label": "Community",
 			"repo": "reaction-docs",
 			"docPath": "developer/community.md"
 		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "community-resources",
-			"label": "Community resources",
-			"repo": "reaction-docs",
-			"docPath": "developer/community-resources.md"
-		}, {
 			"class": "guide-nav-item",
-			"alias": "tutorial",
-			"label": "Customization Guide",
-			"repo": "reaction-docs",
-			"docPath": "developer/tutorial/introduction.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "creating-a-theme",
-			"label": "Creating a Theme",
-			"repo": "reaction-docs",
-			"docPath": "developer/tutorial/creating-a-theme.md"
-		}, {
-			"class": "guide-sub-nav-item",
 			"alias": "plugin-intro-1",
-			"label": "Introduction",
+			"label": "Plugin Tutorial",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-intro-1.md"
 		}, {
@@ -164,15 +152,33 @@
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-complete-10.md"
 		}, {
+			"class": "guide-nav-item",
+			"alias": "tutorial",
+			"label": "Customization Guides",
+			"repo": "reaction-docs",
+			"docPath": "developer/tutorial/introduction.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "creating-a-theme",
+			"label": "Theme: Creating a Theme",
+			"repo": "reaction-docs",
+			"docPath": "developer/tutorial/creating-a-theme.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "appearance",
+			"label": "Themes: Right-to-left",
+			"repo": "reaction-docs",
+			"docPath": "developer/themes/themes.md"
+		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "creating-a-payment-provider",
-			"label": "Creating a Payment Provider",
+			"label": "Payments: Creating a Payment Provider",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/creating-a-payment-provider-plugin.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "extending-product-schema-location-map",
-			"label": "Extending the product schema for Google map",
+			"label": "Tutorial: Extending the product schema for Google map",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/extending-product-schema-location-map.md"
 		}, {
@@ -193,18 +199,18 @@
 			"label": "Tutorial: Debugging server-side code",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/tutorial-debugging-server-code.md"
-    },{
-			"class": "guide-sub-nav-item",
-			"alias": "appearance",
-			"label": "Themes: Right-to-left",
-			"repo": "reaction-docs",
-			"docPath": "developer/themes/themes.md"
-		}, {
+    }, {
 			"class": "guide-sub-nav-item",
 			"alias": "register-template",
-			"label": "Create Custom Templates",
+			"label": "Email: Create Custom E-mail Templates",
 			"repo": "reaction-docs",
 			"docPath": "developer/themes/register-template.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "register-email",
+			"label": "Email: Customize Email Templates",
+			"repo": "reaction-docs",
+			"docPath": "developer/themes/register-email.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "register-component",
@@ -213,18 +219,11 @@
 			"docPath": "developer/themes/register-component.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "register-email",
-			"label": "Customize Email Templates",
-			"repo": "reaction-docs",
-			"docPath": "developer/themes/register-email.md"
-		}, {
-			"class": "guide-sub-nav-item",
 			"alias": "fixtures-images",
-			"label": "Fixtures: Upload images",
+			"label": "Tutorial: Upload images as data fixtures",
 			"repo": "reaction-docs",
 			"docPath": "developer/data-fixtures-insert-product-images.md"
-		},
-		{
+		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "template-helpers",
 			"label": "Helpers",
@@ -356,12 +355,6 @@
 			"label": "Analytics",
 			"repo": "reaction-docs",
 			"docPath": "developer/core/analytics.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "email-api",
-			"label": "Email",
-			"repo": "reaction-docs",
-			"docPath": "developer/core/email.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "i18n",

--- a/redoc.json
+++ b/redoc.json
@@ -56,48 +56,6 @@
 			"repo": "reaction-docs",
 			"docPath": "developer/developer-faqs.md"
 		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "styleguide",
-			"label": "Code Style Guide",
-			"repo": "reaction-docs",
-			"docPath": "developer/styleguide.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "git-style-guide",
-			"label": "Git Style Guide",
-			"repo": "reaction-docs",
-			"docPath": "developer/git-style-guide.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "react-best-practices",
-			"label": "React Best Practices",
-			"repo": "reaction-docs",
-			"docPath": "developer/react-best-practices.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "contributing-to-reaction",
-			"label": "Contributing Guide",
-			"repo": "reaction-docs",
-			"docPath": "developer/contributing.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "developer-faq",
-			"label": "FAQs",
-			"repo": "reaction-docs",
-			"docPath": "developer/developer-faqs.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "community-channels",
-			"label": "Community",
-			"repo": "reaction-docs",
-			"docPath": "developer/community.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "community-resources",
-			"label": "Community resources",
-			"repo": "reaction-docs",
-			"docPath": "developer/community-resources.md"
-		}, {
 			"class": "guide-nav-item",
 			"alias": "plugin-intro-1",
 			"label": "Plugin Tutorial",
@@ -235,6 +193,42 @@
 			"label": "Helpers",
 			"repo": "reaction-docs",
 			"docPath": "developer/themes/helpers.md"
+		}, {
+			"class": "guide-nav-item",
+			"alias": "contributing-to-reaction",
+			"label": "Contributing Guide",
+			"repo": "reaction-docs",
+			"docPath": "developer/contributing.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "styleguide",
+			"label": "Code Style Guide",
+			"repo": "reaction-docs",
+			"docPath": "developer/styleguide.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "git-style-guide",
+			"label": "Git Style Guide",
+			"repo": "reaction-docs",
+			"docPath": "developer/git-style-guide.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "react-best-practices",
+			"label": "React Best Practices",
+			"repo": "reaction-docs",
+			"docPath": "developer/react-best-practices.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "community-channels",
+			"label": "Community",
+			"repo": "reaction-docs",
+			"docPath": "developer/community.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "community-resources",
+			"label": "Community resources",
+			"repo": "reaction-docs",
+			"docPath": "developer/community-resources.md"
 		}, {
 			"class": "guide-nav-item",
 			"alias": "architecture",

--- a/redoc.json
+++ b/redoc.json
@@ -86,6 +86,12 @@
 			"repo": "reaction-docs",
 			"docPath": "developer/community.md"
 		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "community-resources",
+			"label": "Community resources",
+			"repo": "reaction-docs",
+			"docPath": "developer/community-resources.md"
+		}, {
 			"class": "guide-nav-item",
 			"alias": "plugin-intro-1",
 			"label": "Plugin Tutorial",

--- a/redoc.json
+++ b/redoc.json
@@ -51,6 +51,12 @@
 			"docPath": "developer/configuration.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "developer-faq",
+			"label": "Developer FAQs",
+			"repo": "reaction-docs",
+			"docPath": "developer/developer-faqs.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "styleguide",
 			"label": "Code Style Guide",
 			"repo": "reaction-docs",
@@ -73,12 +79,6 @@
 			"label": "Contributing Guide",
 			"repo": "reaction-docs",
 			"docPath": "developer/contributing.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "developer-faq",
-			"label": "FAQs",
-			"repo": "reaction-docs",
-			"docPath": "developer/developer-faqs.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "community-channels",

--- a/redoc.json
+++ b/redoc.json
@@ -51,6 +51,12 @@
 			"docPath": "developer/configuration.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "developer-faq",
+			"label": "FAQs",
+			"repo": "reaction-docs",
+			"docPath": "developer/developer-faqs.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "styleguide",
 			"label": "Code Style Guide",
 			"repo": "reaction-docs",

--- a/redoc.json
+++ b/redoc.json
@@ -51,12 +51,6 @@
 			"docPath": "developer/configuration.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "email-api",
-			"label": "Email",
-			"repo": "reaction-docs",
-			"docPath": "developer/core/email.md"
-		}, {
-			"class": "guide-sub-nav-item",
 			"alias": "styleguide",
 			"label": "Code Style Guide",
 			"repo": "reaction-docs",
@@ -355,6 +349,12 @@
 			"label": "Analytics",
 			"repo": "reaction-docs",
 			"docPath": "developer/core/analytics.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "email-api",
+			"label": "Email",
+			"repo": "reaction-docs",
+			"docPath": "developer/core/email.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "i18n",

--- a/redoc.json
+++ b/redoc.json
@@ -51,12 +51,6 @@
 			"docPath": "developer/configuration.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "email-api",
-			"label": "Email",
-			"repo": "reaction-docs",
-			"docPath": "developer/core/email.md"
-		}, {
-			"class": "guide-sub-nav-item",
 			"alias": "styleguide",
 			"label": "Code Style Guide",
 			"repo": "reaction-docs",
@@ -362,6 +356,12 @@
 			"label": "Analytics",
 			"repo": "reaction-docs",
 			"docPath": "developer/core/analytics.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "email-api",
+			"label": "Email",
+			"repo": "reaction-docs",
+			"docPath": "developer/core/email.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "i18n",

--- a/redoc.json
+++ b/redoc.json
@@ -16,15 +16,9 @@
 		}, {
 			"class": "guide-nav-item",
 			"alias": "getting-started-developing-with-reaction",
-			"label": "Developer",
+			"label": "Getting started",
 			"repo": "reaction-docs",
 			"docPath": "developer/getting-started.md"
-		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "community-resources",
-			"label": "Community resources",
-			"repo": "reaction-docs",
-			"docPath": "developer/community-resources.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "installation",
@@ -97,6 +91,12 @@
 			"label": "Community",
 			"repo": "reaction-docs",
 			"docPath": "developer/community.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "community-resources",
+			"label": "Community resources",
+			"repo": "reaction-docs",
+			"docPath": "developer/community-resources.md"
 		}, {
 			"class": "guide-nav-item",
 			"alias": "tutorial",

--- a/redoc.json
+++ b/redoc.json
@@ -94,55 +94,55 @@
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-creating-2",
-			"label": "Creating your plugin",
+			"label": "Part 1: Creating your plugin",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-creating-2.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-layouts-3",
-			"label": "Layouts",
+			"label": "Part 2: Layouts",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-layouts-3.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-customizing-templates-4",
-			"label": "Customizing Templates",
+			"label": "Part 3: Customizing Templates",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-customizing-templates-4.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-fixtures-5",
-			"label": "Fixtures",
+			"label": "Part 4: Fixtures",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-fixtures-5.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-routes-6",
-			"label": "Routes",
+			"label": "Part 5: Routes",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-routes-6.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-workflow-7",
-			"label": "Workflow",
+			"label": "Part 6: Workflow",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-workflow-7.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-schemas-8",
-			"label": "Schemas",
+			"label": "Part 7: Schemas",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-schemas-8.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-i18n-9",
-			"label": "i18n",
+			"label": "Part 8: i18n",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-i18n-9.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "plugin-complete-10",
-			"label": "Completing your plugin",
+			"label": "Part 9: Completing your plugin",
 			"repo": "reaction-docs",
 			"docPath": "developer/tutorial/plugin-complete-10.md"
 		}, {


### PR DESCRIPTION
closes #328 and #110

- adds new sections: `Plugin Tutorial`,  `Getting started`, `Contributing`, `Guides`
- WIP: add new Start page, a la https://docs.djangoproject.com/en/2.0/
- experience it IRL: https://docs.reactioncommerce.com/reaction-docs/328-machikoyasuda-toc-best-practices/intro

before:

![screen shot 2018-01-18 at 4 36 41 pm](https://user-images.githubusercontent.com/3673236/35128937-dfde7ea6-fc6d-11e7-8bbf-43a2ec014b1a.png)

after:
![screen shot 2018-01-18 at 4 37 01 pm](https://user-images.githubusercontent.com/3673236/35128938-dff96fd6-fc6d-11e7-9e27-ef5a07eea03d.png)
