### PR TITLE
fix: Updated bad link path on git style guide page

### DIFF
--- a/developer/git-style-guide.md
+++ b/developer/git-style-guide.md
@@ -46,4 +46,4 @@ Follow the [PR template](https://github.com/reactioncommerce/reaction/blob/maste
 
 ## Wait for a code review
 
-Congrats! You made a pull request. Head to the [Code review process guide](/developer/code-review.md) to see what's next.
+Congrats! You made a pull request. Head to the [Code review process guide](/developer/code-reviews.md) to see what's next.


### PR DESCRIPTION
At the bottom of the [Git style guide](https://docs.reactioncommerce.com/reaction-docs/master/git-style-guide) page the link to the **code review process guide** was  returning `404`. The URL path was `/developer/code-review.md` I've updated it to be `/developer/code-reviews.md`. I figured it was better to update the URL path rather than changing the `code-reviews.md` file name.