### PR TITLE
Use sudo in Linux installation docs

### DIFF
--- a/developer/installation/installation-linux.md
+++ b/developer/installation/installation-linux.md
@@ -37,7 +37,7 @@ curl https://install.meteor.com/ | sh
 
 ```sh
 # install CLI
-sudo npm install -g reaction-cli
+npm install -g reaction-cli
 ```
 
 ### Create your first Reaction project

--- a/developer/installation/installation-linux.md
+++ b/developer/installation/installation-linux.md
@@ -11,17 +11,17 @@ Follow the instructions at [NodeJs site](https://nodejs.org)
 For Ubuntu/Debian
 
 ```sh
-apt-get update
+sudo apt-get update
 
-apt-get install -y --no-install-recommends build-essential bzip2 curl ca-certificates git graphicsmagick python
+sudo apt-get install -y --no-install-recommends build-essential bzip2 curl ca-certificates git graphicsmagick python
 ```
 
 For CentOS/RHEL
 
 ```sh
-yum groupinstall "Development Tools"
+sudo yum groupinstall "Development Tools"
 # add "Extra Packages for Enterprise Linux" repository for GraphicsMagick
-yum install epel-release  GraphicsMagick
+sudo yum install epel-release GraphicsMagick
 ```
 
 ### Install Meteor
@@ -37,7 +37,7 @@ curl https://install.meteor.com/ | sh
 
 ```sh
 # install CLI
-npm install -g reaction-cli
+sudo npm install -g reaction-cli
 ```
 
 ### Create your first Reaction project


### PR DESCRIPTION
The current Linux installation docs do not differentiate between
commands that need to run as root versus those that don't.  The issue
here is that if everything is run as root then reaction will be run as
root, which shouldn't be necessary. This should hopefully clarify what
to run as root versus the commands that can be run as an unprivileged
user.