### PR TITLE
Add Reaction CLI link to redoc.json

### DIFF
--- a/redoc.json
+++ b/redoc.json
@@ -45,6 +45,12 @@
 			"docPath": "developer/installation/installation-linux.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "reaction-cli",
+			"label": "Reaction CLI",
+			"repo": "reaction-docs",
+			"docPath": "developer/installation/reaction-cli.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "configuration",
 			"label": "Configuration",
 			"repo": "reaction-docs",


### PR DESCRIPTION
Clicking on the CLI docs link on [1] doesn't load any content.

This commit updates redoc.json in an attempt to resolve this.

[1] https://docs.reactioncommerce.com/reaction-docs/master/installation-linux