### PR TITLE
General doc cleanup

### DIFF
--- a/developer/core/email.md
+++ b/developer/core/email.md
@@ -1,6 +1,6 @@
 # Email
 
-Email sending in Reaction is handled by [Nodemailer](https://github.com/nodemailer/nodemailer) and the use of any SMTP server is supported. See the [configuration documentation](/admin/email.md) for details on how to set up mail in the admin dashboard.
+Email sending in Reaction is handled by [Nodemailer](https://github.com/nodemailer/nodemailer) and the use of any SMTP server is supported. See the [configuration documentation](/admin/dashboard/email-admin.md) for details on how to set up mail in the admin dashboard.
 
 All emails that are sent from Reaction are added to a job queue for both logging and failure handling (see [vsivsi:job-collection](https://github.com/vsivsi/meteor-job-collection) for full API docs). While you can add jobs directly to the queue, it is recommended that you use the API outlined below to send emails.
 
@@ -12,7 +12,7 @@ All server side email methods (except Meteor methods) are available in the `Reac
 
 If mail is configured, returns an SMTP URL string.
 
-The following settings are checked in the order shown and the first one that is found with all required parts (host, port, user, password) will be used. See [email configuration](/admin/email.md) for more information.
+The following settings are checked in the order shown and the first one that is found with all required parts (host, port, user, password) will be used. See [email configuration](/admin/dashboard/email-admin.md) for more information.
 
 -   `MAIL_URL` environment variable
 -   `Meteor.settings.MAIL_URL`
@@ -22,7 +22,7 @@ The following settings are checked in the order shown and the first one that is 
 
 If mail is configured, returns a [Nodemailer](https://github.com/nodemailer/nodemailer) configuration object.
 
-The following settings are checked in the order shown and the first one that is found with all required parts (host, port, user, password) will be used. See [email configuration](/admin/email.md) for more information.
+The following settings are checked in the order shown and the first one that is found with all required parts (host, port, user, password) will be used. See [email configuration](/admin/dashboard/email-admin.md) for more information.
 
 -   `MAIL_URL` environment variable
 -   `Meteor.settings.MAIL_URL`

--- a/developer/deploying.md
+++ b/developer/deploying.md
@@ -13,7 +13,7 @@ There are two Docker images available:
 -   [reactioncommerce:reaction](https://hub.docker.com/r/reactioncommerce/reaction/) - the latest stable `master` image.
 -   [reactioncommerce:prequel](https://hub.docker.com/r/reactioncommerce/prequel/) - tagged pre-release builds.
 
-All Reaction [configuration options](configuration.md) can be used with these deployment choices.
+All Reaction [configuration options](/developer/configuration.md) can be used with these deployment choices.
 
 Reaction can be deployed as a [standard Node application](https://guide.meteor.com/deployment.html) or as a [Docker container](https://www.docker.com/).
 

--- a/developer/getting-started.md
+++ b/developer/getting-started.md
@@ -9,7 +9,7 @@ Reaction uses Meteor as a build tool and development environment. Meteor eases R
 
 ## Customization Guide
 
-Looking to customize your store? Check out our [customization guide](/developer/tutorial/customization.md) for a walkthrough, as well as examples on how to create your own custom packages.
+Looking to customize your store? Check out our [customization guide](/developer/tutorial/introduction.md) for a walkthrough, as well as examples on how to create your own custom packages.
 
 ## Local Plugins
 

--- a/developer/tutorial/introduction.md
+++ b/developer/tutorial/introduction.md
@@ -59,7 +59,7 @@ should help you find them.
 
 Or, the plugin tutorial is intended to be read from beginning to end. You can start here
 
-[Plugin Tutorial](/developer/tutorial/creating-a-plugin.md)
+[Plugin Tutorial](/developer/tutorial/plugin-creating-2.md)
 
 ## How do I create a custom payment-provider package?
 


### PR DESCRIPTION
The link /admin/email.md doesn't exist, so we update links to point to
/admin/dashboard/email-admin.md.

The link configuration.md doesn't exist, so we point to
/developer/configuration.md.

The link /developer/tutorial/customization.md was renamed to
/developer/tutorial/introduction.md in a6769b8, so we update the
reference here.

The link /developer/tutorial/creating-a-plugin.md doesn't exist, so we
point to /developer/tutorial/plugin-creating-2.md.