### PR TITLE
(chore): #468 add npm install to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,27 @@ version: 2
 jobs:
   build:
     docker:
+      # specify the version you desire here
       - image: node:8
+
+    working_directory: ~/repo
+
     steps:
       - checkout
-      - run:
-          name: Remark Lint
-          command: npm run lint
+
+      # download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run linting
+      - run: npm run lint

--- a/developer/tutorial/introduction.md
+++ b/developer/tutorial/introduction.md
@@ -1,6 +1,6 @@
 # Customizing with Themes and Plugins
 
-# Purpose
+## Purpose
 
 This tutorial is in two parts, the first parts focuses on creating a custom "theme" which is how you can modify
 the appearance of Reaction without changing any of the original files. The second part deals with creating a custom

--- a/developer/tutorial/introduction.md
+++ b/developer/tutorial/introduction.md
@@ -1,6 +1,6 @@
 # Customizing with Themes and Plugins
 
-## Purpose
+# Purpose
 
 This tutorial is in two parts, the first parts focuses on creating a custom "theme" which is how you can modify
 the appearance of Reaction without changing any of the original files. The second part deals with creating a custom

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "hello@reactioncommerce.com",
   "license": "MIT",
   "scripts": {
-    "lint": "remark .",
+    "lint": "remark . --frail",
     "lint-fix": "remark . -o"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #468 

- Configure CircleCI to run `npm run lint`: I just copied @zenweasel in https://github.com/reactioncommerce/reaction-component-library/blob/master/.circleci/config.yml
- Configure `remark-lint` to Error instead of Warn

## how I tested this:

- I added the `-frail` flag to `npm run lint`
- I purposefully made a linting error
- I pushed up the error
- I observed CircleCI fail:

![screen shot 2018-02-05 at 10 27 52 am](https://user-images.githubusercontent.com/3673236/35821898-6140f984-0a5f-11e8-96d4-42fb67b6f760.png)
![screen shot 2018-02-05 at 10 27 59 am](https://user-images.githubusercontent.com/3673236/35821899-6157cd12-0a5f-11e8-9e53-2d8bd58dccb2.png)

- Then... I fixed the error and pushed it back up so this PR can still pass 💯 