### PR TITLE
Fix typo error in React best practices

### DIFF
--- a/developer/react-best-practices.md
+++ b/developer/react-best-practices.md
@@ -41,7 +41,7 @@ class MyComponent extends Component {
 
 ### Don't
 
-Don't use arrow functions to bind callbacks in `render` fucntions. A new function reference will be created everytime the component is re-rendered.
+Don't use arrow functions to bind callbacks in `render` functions. A new function reference will be created everytime the component is re-rendered.
 
 ```js
 class MyComponent extends Component {


### PR DESCRIPTION

Fix typo error in React best practices