### PR TITLE
Docs 493 nnnnat remove imagemagick

### DIFF
--- a/developer/architecture/images.md
+++ b/developer/architecture/images.md
@@ -1,6 +1,6 @@
 # Image Handling
 
-We are using [CollectionFs](https://github.com/CollectionFS/Meteor-CollectionFS)  for file uploading handling.  There is a [CFS GraphicsMagick](https://github.com/CollectionFS/Meteor-cfs-graphicsmagick) package that handles resizing images when they are uploaded.
+We are using [CollectionFs](https://github.com/CollectionFS/Meteor-CollectionFS) for file uploading handling.  The [Sharp](http://sharp.pixelplumbing.com/en/stable/) package is also included to handle resizing images when they are uploaded.
 
 Media collections are defined in `/lib/collections/collectionFS.js`.
 

--- a/developer/installation/installation-linux.md
+++ b/developer/installation/installation-linux.md
@@ -13,15 +13,13 @@ For Ubuntu/Debian
 ```sh
 apt-get update
 
-apt-get install -y --no-install-recommends build-essential bzip2 curl ca-certificates git graphicsmagick python
+apt-get install -y --no-install-recommends build-essential bzip2 curl ca-certificates git python
 ```
 
 For CentOS/RHEL
 
 ```sh
 yum groupinstall "Development Tools"
-# add "Extra Packages for Enterprise Linux" repository for GraphicsMagick
-yum install epel-release  GraphicsMagick
 ```
 
 ### Install Meteor

--- a/developer/installation/installation-osx.md
+++ b/developer/installation/installation-osx.md
@@ -56,14 +56,6 @@ echo "ulimit -n 65536 65536" >> .bashrc
 source .bashrc
 ```
 
-### Install ImageMagick (Optional but recommended)
-
-ImageMagick is used for image resizing on upload. So generally if you are going to use images you need it.
-
-```sh
-brew install imagemagick
-```
-
 ## Install Reaction
 
 ### Install the Reaction command-line interface (CLI)

--- a/developer/installation/installation-windows.md
+++ b/developer/installation/installation-windows.md
@@ -30,12 +30,6 @@ choco install meteor
 npm install -g windows-build-tools
 ```
 
-### Install ImageMagick (Optional but recommended)
-
-```sh
-choco install imagemagick
-```
-
 ## Install Reaction
 
 ### Install the Reaction command-line interface (CLI)


### PR DESCRIPTION
## Summary
- Removed all install instructions for ImageMagick/GraphicsMagick from install docs.
- Replaced CFS GraphicsMagick link with link to Sharp in image docs.
