### PR TITLE
docs(cli): add more CLI commands, including inspect, linting, etc.

### DIFF
--- a/developer/installation/reaction-cli.md
+++ b/developer/installation/reaction-cli.md
@@ -1,12 +1,33 @@
-### Reaction command-line-client (CLI)
+# Reaction command line cheatsheet
 
-Some handy commands to know
+Reaction ships with all the standard Meteor commands, as documented in the [Meteor Guides](https://docs.meteor.com/commandline.html), along with those from Reaction's own command line interface (CLI). Here are some handy commands to use while developing on Reaction:
 
-#### reaction --help
+## Reaction CLI
 
-`reaction -h` will give you help for the `reaction` command.
+### reaction -v
 
-#### reaction pull
+Before you get started using the Reaction CLI, it's important to make sure you're using the latest version. Use `reaction -v` to check what versions of Node, NPM, Meteor Node, Reaction CLI, Docker and what branch and version of Reaction you are currently running.
+
+```sh
+reaction -v
+
+Node: 9.5.0
+NPM: 5.6.0
+Meteor Node: 8.9.3
+Meteor NPM: 5.5.1
+Reaction CLI: 0.27.0
+Reaction: 1.8.0
+Reaction branch: release-1.8.0
+Docker: 17.12.0-ce
+```
+
+### reaction --help
+
+Shortcut: `-h`
+
+`reaction --help` or `-h` will give you help for the `reaction` command.
+
+### reaction pull
 
 Pull the latest version of Reaction and update dependencies
 
@@ -14,9 +35,9 @@ Pull the latest version of Reaction and update dependencies
 reaction pull
 ```
 
-You could just use `git pull`, but `reaction pull` will update npm modules and other dependencies.
+You could just use `git pull`, but running `reaction pull` will also update npm modules and other dependencies.
 
-#### reaction reset
+### reaction reset
 
 Resets the Reaction database, updates npm modules, and optionally removes `node_modules` before updating.
 
@@ -26,16 +47,44 @@ This will give you a fresh test dataset from `private/data`.
 reaction reset
 ```
 
-To just reset the database you can run
+To just reset the database, pass in the `-n` flag:
 
-```bsh
+```sh
 reaction reset -n
 ```
 
-#### reaction test
+### reaction test
 
-To run the server integration tests
+To run the server integration tests:
 
-#### reaction plugin create <your-plugin-name>
+```sh
+reaction test
+```
 
-This will create a template project in the `/imports/plugin/custom` directory
+### reaction plugin create <your-plugin-name>
+
+This will create a template project in the `/imports/plugin/custom` directory.
+
+## Other useful commands for development
+
+### reaction --inspect
+
+Running reaction with the `--inspect` flag will allow you to use Node's native server-side debugger. To learn more on how to set up the inspector, check out our [debugging documentation](developer/tutorial/tutorial-debugging-server-code.md).
+
+### npm run lint
+
+Use `npm run lint` or alternatively, `npx eslint .` for linting your local files. This ensures you are running the same version of Reaction's ESLint.
+
+### SKIP_FIXTURES=true reaction
+
+Run Reaction _without_ the default sample data store and products. Read more about [fixture options](/developer/configuration.md#overwrite-sample-data).
+
+### meteor mongo
+
+Run `meteor mongo` from your Reaction directory to view and run commands in the MongoDB database directly.
+
+See Meteor's documentation on [`meteor mongo`](https://docs.meteor.com/commandline.html#meteormongo) and MongoDB's documentation on all the [Mongo shell commands](https://docs.mongodb.com/manual/reference/mongo-shell/#mongo-shell-command-history).
+
+## meteor shell
+
+Start the Meteor interactive shell with `meteor shell`. See Meteor's documentation on [`meteor shell`](https://docs.meteor.com/commandline.html#meteorshell).


### PR DESCRIPTION
closes #525 

- adds: `reaction -v`, `--inspect`, `npm run lint`, `SKIP FIXTURES=true`, `meteor mongo`, `meteor shell`