### PR TITLE
docs(errors): add Error messaging page and section

### DIFF
--- a/developer/error-handling-guide.md
+++ b/developer/error-handling-guide.md
@@ -1,0 +1,39 @@
+# Error handling guide
+
+## Error messaging
+
+Reaction uses Meteor's [`Meteor.Error()`](https://docs.meteor.com/api/methods.html#Meteor-Error) to throw general runtime errors to the client and server. Read the Meteor Guide's [Error handling](https://guide.meteor.com/methods.html#throwing-errors) section for more on how to use the method.
+
+### Types of Reaction Meteor error messages
+
+[`Meteor.Error()`](https://docs.meteor.com/api/methods.html#Meteor-Error) takes three arguments, one that is required: `error`, a short machine-readable error code, and two that are optional: `reason`, a human-readable message and `details` for any additional stack trace
+information.
+
+#### Use `error` and `reason` arguments
+
+Reaction requires using both `error` and `reason` arguments:
+
+```js
+Meteor.Error("short-message", "Long message with more detail for users.");
+```
+
+#### Common `errors` and `reasons`
+
+Here is a list of standardized arguments for various error situations:
+
+| error               | reason examples                                                     |
+| ---                |     ---                                                              |
+| `access-denied`     | "Access denied"                                                     |
+| `invalid-parameter` | "X is invalid", "Bad X ID" "X is required"                          |
+| `not-configured`    | "Open Exchange Rates not configured. Configure for current rates."  |
+| `not-found`         | "User not found"                                                    |
+| `not-implemented`   | "Multiple shipping providers is currently not implemented"          |
+| `server-error`      | "Error adding to cart"                                              |
+
+#### Error message guidelines
+
+The above list is not exhaustive throughout the whole app. For other error scenarios, use the guidelines below:
+
+- Do not use HTTP status codes, like `404` or `500`. Use the error messages `invalid-parameter` and `internal-server-error` instead respectively.
+- Always start the reason with a capital letter.
+- Do not use exclamation marks in the reason.

--- a/developer/error-handling-guide.md
+++ b/developer/error-handling-guide.md
@@ -9,7 +9,7 @@ Reaction uses Meteor's [`Meteor.Error()`](https://docs.meteor.com/api/methods.ht
 [`Meteor.Error()`](https://docs.meteor.com/api/methods.html#Meteor-Error) takes three arguments, one that is required: `error`, a short machine-readable error code, and two that are optional: `reason`, a human-readable message and `details` for any additional stack trace
 information.
 
-#### Use `error` and `reason` arguments
+#### Always include both error and reason messages
 
 Reaction requires using both `error` and `reason` arguments:
 
@@ -22,7 +22,7 @@ Meteor.Error("short-message", "Long message with more detail for users.");
 Here is a list of standardized arguments for various error situations:
 
 | error               | reason examples                                                     |
-| ---                |     ---                                                              |
+| ---                 |     ---                                                             |
 | `access-denied`     | "Access denied"                                                     |
 | `invalid-parameter` | "X is invalid", "Bad X ID" "X is required"                          |
 | `not-configured`    | "Open Exchange Rates not configured. Configure for current rates."  |
@@ -34,6 +34,6 @@ Here is a list of standardized arguments for various error situations:
 
 The above list is not exhaustive throughout the whole app. For other error scenarios, use the guidelines below:
 
-- Do not use HTTP status codes, like `404` or `500`. Use the error messages `invalid-parameter` and `internal-server-error` instead respectively.
+- Do not use HTTP status codes, like `404` or `500`. Use the error messages `invalid-parameter` and `server-error` instead respectively.
 - Always start the reason with a capital letter.
 - Do not use exclamation marks in the reason.

--- a/redoc.json
+++ b/redoc.json
@@ -238,7 +238,7 @@
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "error-handling-guide",
-			"label": "Error handling guide",
+			"label": "Error Handling Guide",
 			"repo": "reaction-docs",
 			"docPath": "developer/error-handling-guide.md"
 		}, {

--- a/redoc.json
+++ b/redoc.json
@@ -237,6 +237,12 @@
 			"docPath": "developer/jsdoc-style-guide.md"
 		}, {
 			"class": "guide-sub-nav-item",
+			"alias": "error-handling-guide",
+			"label": "Error handling guide",
+			"repo": "reaction-docs",
+			"docPath": "developer/error-handling-guide.md"
+		}, {
+			"class": "guide-sub-nav-item",
 			"alias": "release-process",
 			"label": "Release Guide",
 			"repo": "reaction-docs",


### PR DESCRIPTION
closes #513

I added information from https://github.com/reactioncommerce/reaction/pull/3195 for
```access-denied
not-implemented
invalid-parameter
not-configured
server-error
not-found
``` 
with some background information on `Meteor.Error()` from the Meteor guide.

Test: https://docs.reactioncommerce.com/reaction-docs/513-machikoyasuda-error-messaging/error-handling-guide
