### PR TITLE
docs(contributing): Reference Git branch/commit message guide in Contributing.

### DIFF
--- a/developer/contributing.md
+++ b/developer/contributing.md
@@ -43,7 +43,15 @@ If you are interested in a specific aspect of the project but aren't sure where 
 
 ## Step 3: Prepare a pull request for review
 
-Once your branch fulfills the issue it tackles, you are ready to [create a pull request](https://help.github.com/articles/creating-a-pull-request/) (PR). Your PR will have to meet the following criteria first:
+Once your branch fulfills the issue it tackles, you are ready to [create a pull request](https://help.github.com/articles/creating-a-pull-request/) (PR).
+
+### Use our Git commit message conventions
+
+Follow the [Git Style Guide](/developer/git-style-guide.md) rules outlined in the docs for branch names and commit message styles.
+
+### Give your PR a good title
+
+Title the PR with the ID number of the GitHub issue. Add `WIP` (work in progress) to the beginning of the title if your PR is still in development and you do not want it to be merged.
 
 ### Pass all tests
 

--- a/developer/git-style-guide.md
+++ b/developer/git-style-guide.md
@@ -38,13 +38,3 @@ Examples:
     BREAKING CHANGES: remove Header Blaze template. To migrate to the React component, use HeaderComponent.
 ```
 See more [examples from Angular.js](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#heading=h.8sw072iehlhg).
-
-## Making a pull request
-
-Title the pull request (PR) with the ID number of the GitHub issue. Add `WIP` (work in progress) to the beginning of the title to get feedback early on.
-
-Follow the [PR template](https://github.com/reactioncommerce/reaction/blob/master/.github/pull_request_template.md) provided and make sure to add `Closes ###` with the GitHub issue number.
-
-## Wait for a code review
-
-Congrats! You made a pull request. Head to the [contributing guide](https://docs.reactioncommerce.com/reaction-docs/master/contributing-to-reaction#step-3-the-pull-request-and-review-process) to see what's next.


### PR DESCRIPTION
I noticed we didn't mention the Git branch/commit message guide in the canonical Contributing guide, so I added it in.