### PR TITLE
fix(link): fix Helpers module link and add API Docs Helpers link.

### DIFF
--- a/developer/themes/helpers.md
+++ b/developer/themes/helpers.md
@@ -1,8 +1,10 @@
 # Helpers
 
-There are many Reaction specific helpers available [Template helpers](http://docs.meteor.com/#/full/template_helpers) in the [core/client/helpers folder](https://github.com/reactioncommerce/reaction/tree/master/packages/reaction-core/client/helpers)
+There are many Reaction-specific [Template helpers](http://docs.meteor.com/#/full/template_helpers) available in the [core/modules/client/helpers](https://github.com/reactioncommerce/reaction/tree/v1.8.0/client/modules/core/helpers) folder.
 
 Meteor Template helper docs:
 
 > You can define helpers and event maps on Template.body just like on any Template.myTemplate object.
 > Helpers on Template.body are only available in the `<body>` tags of your app. To register a global helper, use Template.registerHelper. Event maps on Template.body don't apply to elements added to the body via Blaze.render, jQuery, or the DOM API, or to the body element itself. To handle events on the body, window, or document, use jQuery or the DOM API.
+
+See a list of Helper methods in the [API Docs: Helpers](http://api.docs.reactioncommerce.com/Helpers.html).

--- a/redoc.json
+++ b/redoc.json
@@ -194,12 +194,6 @@
 			"repo": "reaction-docs",
 			"docPath": "developer/data-fixtures-insert-product-images.md"
 		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "template-helpers",
-			"label": "Helpers",
-			"repo": "reaction-docs",
-			"docPath": "developer/themes/helpers.md"
-		}, {
 			"class": "guide-nav-item",
 			"alias": "contributing-to-reaction",
 			"label": "Contributing Guide",
@@ -499,6 +493,12 @@
 			"label": "Module Import Cheatsheet",
 			"repo": "reaction-docs",
 			"docPath": "developer/module-cheatsheet.md"
+		}, {
+			"class": "guide-sub-nav-item",
+			"alias": "template-helpers",
+			"label": "Helpers",
+			"repo": "reaction-docs",
+			"docPath": "developer/themes/helpers.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "revision-api",


### PR DESCRIPTION
closes #502 

- updated link to https://github.com/reactioncommerce/reaction/tree/v1.8.0/client/modules/core/helpers
- added link to http://api.docs.reactioncommerce.com/Helpers.html
- moves Helpers link under Architecture, not Tutorials/Guides.