### PR TITLE
Add steps to run App Build with Docker Compose

### DIFF
--- a/developer/configuration.md
+++ b/developer/configuration.md
@@ -1,14 +1,12 @@
 # Configuration
 
-Reaction can be configured on startup with a combination of environment variables, `settings/settings.json`, and default data files for store pre-configuration.
+Reaction can be configured on startup with a combination of environment variables and default data files for store pre-configuration.
 
 Reaction uses `/private/settings/reaction.json` for the configuration of Reaction and [Meteor.settings](http://docs.meteor.com/#/full/meteor_settings) for initial administrator and server setup.
 
 ## Environment variables
 
-You can use [environment variables](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps#how-the-environment-and-environmental-variables-work) for settings, useful for headless and automated virtual machine configuration.
-
-Environment variables take priority over variables set in _settings.json_.
+You should use [environment variables](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps#how-the-environment-and-environmental-variables-work) for settings, useful for headless and automated virtual machine configuration.
 
 You can also assign these variables before the `reaction` command.
 
@@ -55,39 +53,6 @@ To send email you should pre-configure the administrative SMTP email server from
 Reaction supports sending mail over SMTP; the `MAIL_URL` environment variable should be of the form `smtp://USERNAME:PASSWORD@HOST:PORT`.
 
 The Email dashboard provides a UI for quick configuration of the email server as well.
-
-## Settings
-
-You can use custom [Meteor.settings](http://docs.meteor.com/#/full/meteor_settings) by copying `settings/dev.settings.json` to `settings/settings.json`
-
-For convenience, the initial Reaction administrator can be configured here.
-
-Creating a `settings.json` will prevent the default `dev.settings.json` from being loaded when you use the `reaction` command to start Reaction.
-
-Once you have edited the **_settings/settings.json_** you will need to run:
-
-```sh
-reaction reset && reaction
-```
-
-To reset the database.
-
-**_settings/settings.json_**
-
-```json
-{
-  "ROOT_URL": "",
-  "MAIL_URL": "",
-  "reaction": {
-    "REACTION_USER": "<username>",
-    "REACTION_AUTH": "<password>",
-    "REACTION_EMAIL": "<login email>"
-  },
-  "isDebug": "info"
-}
-```
-
-When the [`reaction-cli`](https://www.npmjs.com/package/reaction-cli) npm package is installed, running `reaction` is the equivalent of starting a server with `meteor --raw-logs --settings settings/<your-settings>.json`
 
 ## Initialization
 

--- a/developer/deploying/docker.md
+++ b/developer/deploying/docker.md
@@ -50,8 +50,6 @@ eval "$(docker-machine env reaction-host)"
 
 Now when you run Docker commands, they will be executing on the remote server instead of your local machine. Ok, let's fire up some Docker containers on your new server!
 
-### Docker
-
 If you don't have a customized version of Reaction Commerce, you can use our official release builds that are [available on Docker Hub](https://hub.docker.com/r/reactioncommerce/reaction/) as `reactioncommerce/reaction:latest`. The official releases are built by [Circle CI](https://circleci.com/) every time code is merged into [the master branch on Github](https://github.com/reactioncommerce/reaction/tree/master).
 
 All you need to run the latest stable build of Reaction is a single Docker command (assuming you have a Mongo database hosted somewhere - e.g. [Compose.io](https://compose.io), etc.)
@@ -93,7 +91,7 @@ Once you have your host IP, go to your domain name provider and point your domai
 
 That's it. You're done!  Once your DNS records update, you should then be able to access your deployed Reaction Commerce shop.
 
-## Custom build
+#### Custom build
 
 Let's customize locally, and build your docker image.
 
@@ -133,7 +131,7 @@ mycustom           latest              d21371bbdba3        2 hours ago  359MB
 
 Now to get your image online so your server can access it.
 
-## Publishing on Docker Hub
+#### Publishing on Docker Hub
 
 Log into your dockerhub account:
 
@@ -171,3 +169,29 @@ docker run -d \
   -e REACTION_AUTH="admin-password" \
   mydockerhubuser/mycustom:mytag
 ```
+
+
+### Using Docker Compose
+
+You can use Docker Compose to run both Mongo and Reaction in containers.
+
+We've included a demo [docker-compose file](https://github.com/reactioncommerce/reaction/blob/master/docker-compose-demo.yml) in the repository. In it's current basic form, it is meant for quickly running a demo of your production build. It can also serve as starting point for your production docker-compose setup.
+
+If you have a custom Docker image of your Reaction app, you can modify the `docker-compose-demo.yml` file to point to use it by changing the `image` name of the `reaction` service.
+
+```yml
+services:
+  reaction:
+    image: custom-image
+    depends_on:
+      - mongo
+    ....
+```
+
+Start the app by runnung the `docker-compose up` command and specifying your Compose file
+
+```sh
+docker-compose -f docker-compose-demo.yml up -d
+```
+
+This will pull down the specified Docker images (if not available locally). After pulling, the images are then started for you in the background. You can connect to the logs from your reaction instance with `docker-compose logs reaction --follow` From the logs, you'll see when the app is up and you can then load it in a browser.

--- a/developer/deploying/docker.md
+++ b/developer/deploying/docker.md
@@ -174,7 +174,7 @@ docker run -d \
 
 You can also use Docker Compose to run Reaction and Mongo in separate connected Docker containers.
 
-We've included a demo [docker-compose file](https://github.com/reactioncommerce/reaction/blob/master/docker-compose-demo.yml) in the repository. In it's current basic form, it is meant for quickly running a demo of your production build. It can also serve as starting point for your production docker-compose setup.
+We've included a demo [docker-compose file](https://github.com/reactioncommerce/reaction/blob/master/docker-compose-demo.yml) in the repository. In its current basic form, it is meant for quickly running a demo of your production build. It can also serve as starting point for your production docker-compose setup.
 
 If you have a custom Docker image of your Reaction app, you can modify the `docker-compose-demo.yml` file to point to use it by changing the `image` name of the `reaction` service.
 

--- a/developer/deploying/docker.md
+++ b/developer/deploying/docker.md
@@ -170,7 +170,6 @@ docker run -d \
   mydockerhubuser/mycustom:mytag
 ```
 
-
 ### Using Docker Compose
 
 You can use Docker Compose to run both Mongo and Reaction in containers.

--- a/developer/testing/release-process.md
+++ b/developer/testing/release-process.md
@@ -87,4 +87,3 @@ Notes:
   - [`reaction-swag-shop`](https://github.com/reactioncommerce/reaction-swag-shop)
   - [`payments-cod`](https://github.com/reactioncommerce/payments-cod)
   - [YouTube video tutorials](https://www.youtube.com/playlist?list=PLJ1TVRVOrm2O5OsXqzDn5iZez4WEnKRZH)
-


### PR DESCRIPTION
Docs reflecting Docker Compose file changes in Reaction release-1.9.0

Adds the following lines to deploy.md file.

---------------
### Using Docker Compose

You can also use Docker Compose to run Reaction and Mongo in separate connected Docker containers.

We've included a demo [docker-compose file](https://github.com/reactioncommerce/reaction/blob/master/docker-compose-demo.yml) in the repository. In it's current basic form, it is meant for quickly running a demo of your production build. It can also serve as starting point for your production docker-compose setup.

If you have a custom Docker image of your Reaction app, you can modify the `docker-compose-demo.yml` file to point to use it by changing the `image` name of the `reaction` service.

```yml
services:
  reaction:
    image: custom-image
    depends_on:
      - mongo
    ....
```

Then you start the app by runnung the `docker-compose up` command and specifying your Compose file

```sh
docker-compose -f docker-compose-demo.yml up -d
```

This will pull down the specified Docker images (if not available locally). After pulling, the images are then started for you in the background. You can connect to the logs from your reaction instance with `docker-compose logs reaction --follow` From the logs, you'll see when the app is up and you can then load it in a browser.

-----------------

[View Entire File](https://github.com/reactioncommerce/reaction-docs/blob/a8a08a3580ad1d1348c16db85514487d0ed9f709/developer/deploying/docker.md#using-docker-compose)


-----------------


~## Note: CircleCI's Lint Error
I'm not sure what's going on with CircleCI's Lint error. It's from a file I didn't touch here (and I also don't know how to fix the file)~