### PR TITLE
Add Braintree Subscription plugin to Community Resources

### DIFF
--- a/developer/community-resources.md
+++ b/developer/community-resources.md
@@ -80,7 +80,6 @@ This plugin is **work-in-progress**, but does address a very common request: A R
 
 This is a simple implementation of using Braintree Subscriptions. Simply add a "plan" in your Braintree panel and your customers can checkout using that plan. Updated to work with version >= 1.9
 
-
 ## SEO tools
 
 ### [reaction-commerce-caching-plugin](https://github.com/artlimes/reaction-commerce-caching-plugin)

--- a/developer/community-resources.md
+++ b/developer/community-resources.md
@@ -76,7 +76,10 @@ Kudos to [Loan!](https://github.com/loanlaux)
 
 This plugin is **work-in-progress**, but does address a very common request: A Reaction plugin that does support the most popular subscription billing features. This is because subscriptions play an important and ever increasing role in the ecommerce landscape.
 
-Thank you for helping our ecosystem to grow, [Daniel!](https://github.com/dhonig)
+### [DeligenceTechnologies/Subscription-Recurring-payments-in-Reaction-Commerce-using-Braintree-Payments-Gateway](https://github.com/DeligenceTechnologies/Subscription-Recurring-payments-in-Reaction-Commerce-using-Braintree-Payments-Gateway)
+
+This is a simple implementation of using Braintree Subscriptions. Simply add a "plan" in your Braintree panel and your customers can checkout using that plan. Updated to work with version >= 1.9
+
 
 ## SEO tools
 


### PR DESCRIPTION
I've tested this plugin and it's simple but it works after they merged my PR to update to the current version of simple-schema, etc.

https://github.com/DeligenceTechnologies/Subscription-Recurring-payments-in-Reaction-Commerce-using-Braintree-Payments-Gateway/pull/1#issuecomment-377469767