### PR TITLE
hotfix: reaction importer url is breaking

### DIFF
--- a/redoc.json
+++ b/redoc.json
@@ -495,7 +495,7 @@
 			"docPath": "developer/core/orders.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "reaction-importer",
+			"alias": "reaction-import",
 			"label": "Importer",
 			"repo": "reaction-docs",
 			"docPath": "developer/core/import.md"

--- a/redoc.json
+++ b/redoc.json
@@ -498,7 +498,7 @@
 			"alias": "reaction-importer",
 			"label": "Importer",
 			"repo": "reaction-docs",
-			"docPath": "developer/core/importer.md"
+			"docPath": "developer/core/import.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "reaction-inventory",


### PR DESCRIPTION
Fix the path to https://github.com/reactioncommerce/reaction-docs/blob/master/developer/core/import.md