### PR TITLE
(fix) Update prerender guide

### DIFF
--- a/developer/architecture/prerender.md
+++ b/developer/architecture/prerender.md
@@ -22,7 +22,7 @@ To test that your integration with [prerender.io](prerender.io) works, append `?
 https://example.com/product/example-product?_escaped_fragment_=
 ```
 
-You should then see the URL cached in your [prerender.io](prerender.io) dashboard.
+You should then see the URL cached in your [prerender.io dashboard](prerender.io).
 
 ## Customization
 

--- a/developer/architecture/prerender.md
+++ b/developer/architecture/prerender.md
@@ -8,12 +8,21 @@ To enable prerender for your app set the following environment variables
 
 ```shell
 PRERENDER_TOKEN: YOURTOKEN
+PRERENDER_SERVICE_URL: http://service.prerender.io/
 PRERENDER_HOST: example.com
 ```
 
 You can find your `PRERENDER_TOKEN` on your [prerender.io account page](https://prerender.io/account)
 
-Your `PRERENDER_HOST` should be the domain your app is using (e.g. `example.com` or `www.example.com`)
+Your `PRERENDER_HOST` should be the domain your app is using (e.g. `example.com` or `www.example.com`).
+
+To test that your integration with [prerender.io](prerender.io) works, append `?_escaped_fragment_=` to one of your site's URLs and load it on a browser. For example,
+
+```shell
+https://example.com/product/example-product?_escaped_fragment_=
+```
+
+You should then see the URL cached in your [prerender.io](prerender.io) dashboard.
 
 ## Customization
 

--- a/developer/contributing.md
+++ b/developer/contributing.md
@@ -24,13 +24,12 @@ Once your bug issue is filed, the community team will evaluate and prioritize us
 - **impact-major** (do next): Blocks important functionality but there is a workaround or the problem doesn't inhibit shopping/purchasing
 - **impact-minor** (do eventually): Impacts peripheral functionality or there is a reasonable workaround (UI glitches, etc)
 
-Once it's been triaged and verified, a Community Engineering team member will work on it according the above criteria.
+Once it's been triaged and verified, a team member will work on it according the above criteria.
 
 ### Find an issue and claim it
 
 1. Explore the [Help Wanted](https://github.com/reactioncommerce/reaction/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [Good First Issue](https://github.com/reactioncommerce/reaction/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) issues on our GitHub repo.
 2. If you find something you want to work on, let us know right there in the comment with how you want to approach the problem.
-3. If you are a first-time contributor, also mention the `@reactioncommerce/community` team in the comment so you can  request to be made a contributor.
 
 ### Create a Feature Request issue
 
@@ -108,7 +107,7 @@ Before you are ready for a team code review, you will also have to fill out the 
 
 ## Step 4: PR review process begins
 
-The Community team triages all new pull requests as soon as the PR is complete.
+The team triages all new pull requests as soon as the PR is complete.
 
 ### PR gets reviewed
 
@@ -145,9 +144,5 @@ Reviewers will note any changes that they will want to QA in the app, even if th
 ## Step 5: Congrats! It's approved. What happens next?
 
 The Reaction team reviewer is responsible for merging the PRs they approved, unless the PR submitter has requested otherwise.
-
-Does your new feature require new user documentation or developer documentation? Make an issue for that in [reaction-docs](https://github.com/reactioncommerce/reaction-docs/issues).
-
-## Step 5: Congrats! It's merged. What happens next?
 
 Now that your PR is merged, the feature will be released in the next release. Head on over to our [Release Guide](/developer/testing/release-process.md) for more on how we release versions of Reaction.

--- a/developer/installation/installation-linux.md
+++ b/developer/installation/installation-linux.md
@@ -4,7 +4,9 @@
 
 ### Install Node
 
-Follow the instructions at [NodeJs site](https://nodejs.org)
+Follow the instructions at [Node.js site](https://nodejs.org) for the latest long-term support (LTS) version, 8.
+
+**Note:** Reaction is currently not compatible with Node 9.
 
 ### Install Build Tools and Package Requirements
 

--- a/developer/installation/installation-osx.md
+++ b/developer/installation/installation-osx.md
@@ -6,7 +6,9 @@
 
 ### Install Node
 
-Download and run the installer from the [NodeJs site](https://nodejs.org)
+Download and run the installer from the [Node.js site](https://nodejs.org) for the latest long-term support (LTS) version, 8.
+
+**Note:** Reaction is currently not compatible with Node 9.
 
 ### Install Xcode
 

--- a/developer/installation/installation-windows.md
+++ b/developer/installation/installation-windows.md
@@ -8,7 +8,9 @@
 
 ### Install Node
 
-Download and run the installer from the [NodeJs site](https://nodejs.org)
+Download and run the installer from the [Node.js site](https://nodejs.org) for the latest long-term support (LTS) version, 8.
+
+**Note:** Reaction is currently not compatible with Node 9.
 
 ### Install Chocolately
 

--- a/redoc.json
+++ b/redoc.json
@@ -809,12 +809,6 @@
 			"repo": "reaction-docs",
 			"docPath": "developer/deploying/docker.md"
 		}, {
-			"class": "guide-sub-nav-item",
-			"alias": "deploying-on-reaction-platform",
-			"label": "Reaction Platform",
-			"repo": "reaction-docs",
-			"docPath": "developer/deploying/platform.md"
-		}, {
 			"class": "guide-nav-item",
 			"alias": "dashboard",
 			"label": "Store Operator's Guide",

--- a/redoc.json
+++ b/redoc.json
@@ -495,7 +495,7 @@
 			"docPath": "developer/core/orders.md"
 		}, {
 			"class": "guide-sub-nav-item",
-			"alias": "reaction-importer",
+			"alias": "reaction-import",
 			"label": "Importer",
 			"repo": "reaction-docs",
 			"docPath": "developer/core/import.md"

--- a/redoc.json
+++ b/redoc.json
@@ -498,7 +498,7 @@
 			"alias": "reaction-importer",
 			"label": "Importer",
 			"repo": "reaction-docs",
-			"docPath": "developer/core/importer.md"
+			"docPath": "developer/core/import.md"
 		}, {
 			"class": "guide-sub-nav-item",
 			"alias": "reaction-inventory",


### PR DESCRIPTION
If https://github.com/reactioncommerce/reaction/pull/4331 gets merged, then the docs on prerender have to be updated as suggested in this PR.