### PR TITLE
(fix): correct text for lint and test commands

### DIFF
--- a/public-docs/contributing-to-reaction.md
+++ b/public-docs/contributing-to-reaction.md
@@ -59,8 +59,8 @@ Title the PR with the ID number of the GitHub issue. Add `WIP` (work in progress
 
 As soon as your PR is pushed, automated test run to ensure:
 
-- `npm run lint`: Pass current continuous integration tests
-- `reaction test`: Pass linter code review and follow Reaction style guidelines
+- `npm run lint`: Pass linter code review and follow Reaction style guidelines
+- `reaction test`: Pass current continuous integration tests
 
 ### Fill out the pull request template
 


### PR DESCRIPTION
Resolves: Unreported issue
Impact: **minor**  
Type: **docs**

## Issue
Descriptions for the `npm run lint` and `reaction test` commands were backwards.

## Solution
Switched descriptions

## Breaking changes
None

## Testing
1. Visit the main "Contributing Guide" page -> "Pass all tests"
2. Confirm the description for `npm run lint` reads "Pass linter code review and follow Reaction style guidelines".
3. Confirm the description for `reaction test` reads "Pass current continuous integration tests"