### PR TITLE
Update registerPackage import path in plugin tutorial

### DIFF
--- a/public-docs/plugin-creating-2.md
+++ b/public-docs/plugin-creating-2.md
@@ -35,7 +35,7 @@ a plugin. The `register.js` adds your plugin to the Registry, the Packages colle
 
 ```js
 // register.js
-import { Reaction } from "/server/api";
+import Reaction from "/imports/plugins/core/core/server/Reaction";
 
 Reaction.registerPackage({
   label: "Bees Knees",


### PR DESCRIPTION
Impact: **major**  
Type: **docs**

## Issue
Import path for the `registerPackage` method was outdated in the plugin tutorial.

## Solution & Screenshots
Update the import path to `/imports/plugins/core/core/server/Reaction`.