### PR TITLE
docs(1.16): use Reaction.getUserId() instead of Meteor.userId()

### DIFF
--- a/public-docs/permissions.md
+++ b/public-docs/permissions.md
@@ -194,7 +194,7 @@ You can also pass in an `audience` field to filter returned apps based on assign
   Reaction.Apps({
     provides: "settings",
     enabled: true,
-    audience: Roles.getRolesForUser(Meteor.userId(), Reaction.getShopId())
+    audience: Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId())
   })
 ```
 

--- a/public-docs/reaction-orders.md
+++ b/public-docs/reaction-orders.md
@@ -36,7 +36,7 @@ Called when any Order event occurs. The first occurrence is when a user clicks o
 history: {
   event: event,
   value: value,
-  userId: Meteor.userId(),
+  userId: Reaction.getUserId(),
   updatedAt: new Date()
 }
 ```

--- a/public-docs/reaction-payments.md
+++ b/public-docs/reaction-payments.md
@@ -48,7 +48,7 @@ MethodHooks.after("cart/submitPayment", function (options) {
   let result = options.result || {};
   if (typeof options.error === "undefined") {
     let cart = Cart.findOne({
-      userId: Meteor.userId()
+      userId: Reaction.getUserId()
     });
     // update workflow
     Meteor.call("workflow/pushCartWorkflow", "coreCartWorkflow",

--- a/public-docs/reaction-user-accounts.md
+++ b/public-docs/reaction-user-accounts.md
@@ -74,7 +74,7 @@ Template.updateAddressBook.events({
       // More fields needed for a full address
       address1: event.target.address1.value
     };
-    const accountUserId = Meteor.userId();
+    const accountUserId = Reaction.getUserId();
     const type = "shipping";
 
     Meteor.call("accounts/addressBookUpdate", address, accountUserId, type, (error, result) => {


### PR DESCRIPTION
Resolves #658   
Impact: **minor**  
Type: **docs|chore**

## Issue

Update docs for 1.16 - use `Reaction.getUserId()` instead of `Meteor.userId()`

