### PR TITLE
update get in touch buttons to point to act on form

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -50,7 +50,7 @@ class Footer extends React.Component {
               <ul className="footer-list">
                 <li><a target="_blank" href="https://reactioncommerce.com/partners">Partner</a></li>
                 <li><a target="_blank" href="https://reactioncommerce.com/contributors">Contribute</a></li>
-                <li><a target="_blank" href="#get-in-touch">Get in Touch</a></li>
+                <li><a target="_blank" href="http://marketing.reactioncommerce.com/acton/media/37362/get-in-touch">Get in Touch</a></li>
               </ul>
             </div>
 

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -28,7 +28,7 @@ const siteConfig = {
   headerLinks: [
     { doc: "intro", label: "Docs" },
     { search: true },
-    { href: "https://reactioncommerce.com/#get-in-touch", label: "Get in touch" }
+    { href: "http://marketing.reactioncommerce.com/acton/media/37362/get-in-touch", label: "Get in touch" }
   ],
   cleanUrl: true,
   /* path to images for header/footer */


### PR DESCRIPTION
Resolves reactioncommerce/reaction-static#131
Impact: **minor**  
Type: **chore**

## Issue
The Get in Touch button needs to be pointed to the Act On form.

## Solution & Screenshots

Updates the link to point to the right page.
