### PR TITLE
Add Hydra dev docs

### DIFF
--- a/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
+++ b/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
@@ -5,44 +5,44 @@ sidebar_label: Understanding Hydra Auth Setup
 original_id: understanding-hydra-auth-setup
 ---
 
-Reaction Commerce uses [ORY Hydra](https://github.com/ory/hydra) (Hydra) for authentication. Hydra is an OAuth 2.0 and OpenID Connect Provider. As such, it is capable of issuing access, refresh, and ID Tokens. 
+As of version 2.0, Reaction Commerce uses [ORY Hydra](https://github.com/ory/hydra) (Hydra), an OAuth 2.0 and Open ID Connect Provider, for authentication across the `reaction` and `reaction-next-starterkit` apps. 
 
-Hydra does not offer user management (it does not provide user sign up, user log in, password reset flow),
-but instead uses a redirection-based flow and a REST API to connect with an existing identity provider.
+Hydra issues access, refresh, and ID Tokens, but does not offer user management (like user sign up, log in, password reset flows). Instead, Hydra uses redirects and a REST API to connect with an existing identity provider.
 
-We’ve setup Hydra to use our existing Meteor application as the Identity provider.
-This gives us the benefits of OAuth2 and OpenID Connect while allowing us to use our existing user system.
+The Reaction implementation sets up Hydra to use our existing Meteor application as the Identity provider. This gives us the benefits of OAuth2 and OpenID Connect, while allowing us to use our existing user system. At a high level, when a user of the storefront logs in, the user is redirected from the storefront to Hydra, and then to the Identity provider, in this case, the Reaction API. When the authentication is complete on the Hydra side, Hydra then redirects the user back from the Reaction API to the storefront. From the user interface perspective, the authentication process is seamless across the application. Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
 
-Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
+To get started with [`reaction-hydra`], make sure you have upgraded to Reaction version 2.0. The easiest way to install and run all the application is to use [`reaction-platform`](https://github.com/reactioncommerce/reaction-platform).
 
-## OAuth 2.0 Client Setup
+## Setting up the client
 
-We’ve setup the reaction-hydra repository with a sample client creation script.
-This script registers an OAuth 2.0 Client for the sample storefront ([reaction-next-starterkit](https://github.com/reactioncommerce/reaction-next-starterkit)) into Hydra.
+The [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra) repository is set up with a [sample client creation script](https://github.com/reactioncommerce/reaction-hydra/blob/master/bin/create-clients.sh). This script registers an OAuth 2.0 Client for the sample storefront ([`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit)) into Hydra.
 
-The reaction-next-starterkit app is configured with PassportJS to initiate an OAuth flow for user signin.
-For other available libraries that can be used in interacting with the OAuth server, see this [list](https://www.ory.sh/docs/guides/master/hydra/6-how-to/2-architecture#interacting-with-oauth-20).
+The [`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit/) is configured with [Passport.js](http://www.passportjs.org/) to initiate an OAuth flow for user signin. See the [server.js](https://github.com/reactioncommerce/reaction-next-starterkit/blob/v0.1.0/src/server.js) file for configuration details. For other available libraries that can be used in interacting with the OAuth server, see this [list](https://www.ory.sh/docs/guides/master/hydra/6-how-to/2-architecture#interacting-with-oauth-20).
 
-If your OAuth client (relying party) is a Single-Page Application, consider using the Implicit flow and client-side OIDC libraries (example [repo on GitHub](https://github.com/IdentityModel/oidc-client-js)).
+If your OAuth client, the relying party, is a Single-Page Application, consider using the implicit flow and client-side OpenID Connect libraries (example [repo on GitHub](https://github.com/IdentityModel/oidc-client-js)).
 
-## Identity Provider Setup (IDP)
+## Setting up the Identity Provider (IDP)
 
-As mentioned above, Hydra does not provide user management. We are using our existing Meteor User Accounts system in the Reaction API app. We’ve added a `hydra-oauth` plugin that adds IDP features to the app.
+As mentioned above, Hydra does not provide user management. Reaction uses the existing Meteor User Accounts system in the Reaction API app. The [`hydra-oauth`](https://github.com/reactioncommerce/reaction/tree/v2.0.0-rc.3/imports/plugins/core/hydra-oauth) core plugin in [`reaction`](https://github.com/reactioncommerce/reaction/) adds IDP features to the app.
+
 This plugin enables both User Login and Consent Flows. Read more about these flows [here](https://www.ory.sh/docs/guides/master/hydra/3-overview/1-oauth2#implementing-a-login--consent-provider).
 
-The `hydra-oauth` plugin can serve as a reference for creating extra IDP features.
-Note that the Consent flow in this plugin skips showing a Consent UI because it’s built for  the storefront as a is a first-party [known and trusted] client, if your use case is different, you should have a setup that shows a Consent UI when necessary. Read more about this on Hydra [docs](https://www.ory.sh/docs/guides/master/hydra/3-overview/1-oauth2#user-consent).
+Note that the Consent flow in this plugin skips showing a Consent UI because it’s built for the storefront as a first-party [known and trusted] client. If your use case is different, you should have a setup that shows a Consent UI when necessary. Read more about this on Hydra [docs](https://www.ory.sh/docs/guides/master/hydra/3-overview/1-oauth2#user-consent).
 
+This plugin can serve as a reference to create extra IDP features.
+
+## Customizing the interface
+
+The [`hydra-oauth`](https://github.com/reactioncommerce/reaction/tree/v2.0.0-rc.3/imports/plugins/core/hydra-oauth) also provides the React component for the log in user interface. To change basic colors and typography, use the CSS styles applied in [`templates.html`](https://github.com/reactioncommerce/reaction/blob/v2.0.0-rc.3/imports/plugins/core/hydra-oauth/client/templates.html). To use your own login form and add different user interactions, look at the React template in the [`client`](https://github.com/reactioncommerce/reaction/tree/v2.0.0-rc.3/imports/plugins/core/hydra-oauth/client) and replace the component with your own using the Reaction [`replaceComponent`](http://localhost:4000/docs/components-api#replacing-components) API.
 
 ## Troubleshooting Guide
 
 * Read the Debugging guide on the [Hydra docs](https://www.ory.sh/docs/guides/master/hydra/6-how-to/4-debug)
-* If you’re getting errors about your client configuration options (e.g `unknown client no client authentication included, or unsupported authentication method`), use the examples in the [Ory Examples repo on Github](https://github.com/ory/examples/tree/master/full-stack/config/hydra/clients) as reference
-* To edit or delete a client configuration (in case of a wrong configuration), use the hydra CLI contained in the image to run provided commands e.g
+* If you’re getting errors about your client configuration options (e.g `unknown client no client authentication included, or unsupported authentication method`), use the examples in the [ORY Examples repo on Github](https://github.com/ory/examples/tree/master/full-stack/config/hydra/clients) as reference
+* To edit or delete a client configuration (in case of a wrong configuration), use the Hydra CLI contained in the image to run provided commands e.g
     * `hydra clients delete $CLIENT_NAME`
     * `hydra -h` (shows full list of options)
     * You can run the commands with docker-compose as: `docker-compose run --rm -e "HYDRA_ADMIN_URL=$HYDRA_ADMIN_URL” hydra clients get $CLIENT_NAME`
-
 
 ## Hydra in Production
 * Read the [ORY Hydra in Production Guide](https://www.ory.sh/docs/guides/master/hydra/6-how-to/1-production)

--- a/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
+++ b/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
@@ -11,7 +11,7 @@ Hydra issues access, refresh, and ID Tokens, but does not offer user management 
 
 The Reaction implementation sets up Hydra to use our existing Meteor application as the Identity provider. This gives us the benefits of OAuth2 and OpenID Connect, while allowing us to use our existing user system.
 
-At a high level, when a user of the storefront logs in, the user is redirected from the storefront to Hydra, and then to the Identity provider, in this case, the Reaction API. When the authentication is complete on the Hydra side, Hydra then redirects the user back to the storefront. From the user interface perspective, the authentication process is seamless across the application.
+At a high level, when a user of the storefront logs in, the user is redirected from the storefront to Hydra, and then to the Identity provider, in this case, the Reaction API. When the authentication is complete on the Reaction app, Hydra handles the redirects between the Reaction app to the Storefront. From the user interface perspective, the authentication process is seamless across the application.
 
 Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
 

--- a/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
+++ b/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
@@ -1,0 +1,49 @@
+---
+id: version-2.0.0-rc.1-understanding-hydra-auth-setup
+title: Understanding Hydra Auth Setup
+sidebar_label: Understanding Hydra Auth Setup
+original_id: understanding-hydra-auth-setup
+---
+
+Reaction Commerce uses [ORY Hydra](https://github.com/ory/hydra) (Hydra) for authentication. Hydra is an OAuth 2.0 and OpenID Connect Provider. As such, it is capable of issuing access, refresh, and ID Tokens. 
+
+Hydra does not offer user management (it does not provide user sign up, user log in, password reset flow),
+but instead uses a redirection-based flow and a REST API to connect with an existing identity provider.
+
+We’ve setup Hydra to use our existing Meteor application as the Identity provider.
+This gives us the benefits of OAuth2 and OpenID Connect while allowing us to use our existing user system.
+
+Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
+
+## OAuth 2.0 Client Setup
+
+We’ve setup the reaction-hydra repository with a sample client creation script.
+This script registers an OAuth 2.0 Client for the sample storefront ([reaction-next-starterkit](https://github.com/reactioncommerce/reaction-next-starterkit)) into Hydra.
+
+The reaction-next-starterkit app is configured with PassportJS to initiate an OAuth flow for user signin.
+For other available libraries that can be used in interacting with the OAuth server, see this [list](https://www.ory.sh/docs/guides/master/hydra/6-how-to/2-architecture#interacting-with-oauth-20).
+
+If your OAuth client (relying party) is a Single-Page Application, consider using the Implicit flow and client-side OIDC libraries (example [repo on GitHub](https://github.com/IdentityModel/oidc-client-js)).
+
+## Identity Provider Setup (IDP)
+
+As mentioned above, Hydra does not provide user management. We are using our existing Meteor User Accounts system in the Reaction API app. We’ve added a `hydra-oauth` plugin that adds IDP features to the app.
+This plugin enables both User Login and Consent Flows. Read more about these flows [here](https://www.ory.sh/docs/guides/master/hydra/3-overview/1-oauth2#implementing-a-login--consent-provider).
+
+The `hydra-oauth` plugin can serve as a reference for creating extra IDP features.
+Note that the Consent flow in this plugin skips showing a Consent UI because it’s built for  the storefront as a is a first-party [known and trusted] client, if your use case is different, you should have a setup that shows a Consent UI when necessary. Read more about this on Hydra [docs](https://www.ory.sh/docs/guides/master/hydra/3-overview/1-oauth2#user-consent).
+
+
+## Troubleshooting Guide
+
+* Read the Debugging guide on the [Hydra docs](https://www.ory.sh/docs/guides/master/hydra/6-how-to/4-debug)
+* If you’re getting errors about your client configuration options (e.g `unknown client no client authentication included, or unsupported authentication method`), use the examples in the [Ory Examples repo on Github](https://github.com/ory/examples/tree/master/full-stack/config/hydra/clients) as reference
+* To edit or delete a client configuration (in case of a wrong configuration), use the hydra CLI contained in the image to run provided commands e.g
+    * `hydra clients delete $CLIENT_NAME`
+    * `hydra -h` (shows full list of options)
+    * You can run the commands with docker-compose as: `docker-compose run --rm -e "HYDRA_ADMIN_URL=$HYDRA_ADMIN_URL” hydra clients get $CLIENT_NAME`
+
+
+## Hydra in Production
+* Read the [ORY Hydra in Production Guide](https://www.ory.sh/docs/guides/master/hydra/6-how-to/1-production)
+* Read the [“Securing Hydra Guide"](https://www.ory.sh/docs/guides/master/hydra/2-environment/1-securing-ory-hydra)

--- a/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
+++ b/website/versioned_docs/version-2.0.0-rc.1/understanding-hydra-setup.md
@@ -9,15 +9,19 @@ As of version 2.0, Reaction Commerce uses [ORY Hydra](https://github.com/ory/hyd
 
 Hydra issues access, refresh, and ID Tokens, but does not offer user management (like user sign up, log in, password reset flows). Instead, Hydra uses redirects and a REST API to connect with an existing identity provider.
 
-The Reaction implementation sets up Hydra to use our existing Meteor application as the Identity provider. This gives us the benefits of OAuth2 and OpenID Connect, while allowing us to use our existing user system. At a high level, when a user of the storefront logs in, the user is redirected from the storefront to Hydra, and then to the Identity provider, in this case, the Reaction API. When the authentication is complete on the Hydra side, Hydra then redirects the user back from the Reaction API to the storefront. From the user interface perspective, the authentication process is seamless across the application. Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
+The Reaction implementation sets up Hydra to use our existing Meteor application as the Identity provider. This gives us the benefits of OAuth2 and OpenID Connect, while allowing us to use our existing user system.
 
-To get started with [`reaction-hydra`], make sure you have upgraded to Reaction version 2.0. The easiest way to install and run all the application is to use [`reaction-platform`](https://github.com/reactioncommerce/reaction-platform).
+At a high level, when a user of the storefront logs in, the user is redirected from the storefront to Hydra, and then to the Identity provider, in this case, the Reaction API. When the authentication is complete on the Hydra side, Hydra then redirects the user back to the storefront. From the user interface perspective, the authentication process is seamless across the application.
+
+Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
+
+To get started with [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra), make sure you have upgraded to Reaction version 2.0. The easiest way to install and run all the application is to use [`reaction-platform`](https://github.com/reactioncommerce/reaction-platform).
 
 ## Setting up the client
 
 The [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra) repository is set up with a [sample client creation script](https://github.com/reactioncommerce/reaction-hydra/blob/master/bin/create-clients.sh). This script registers an OAuth 2.0 Client for the sample storefront ([`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit)) into Hydra.
 
-The [`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit/) is configured with [Passport.js](http://www.passportjs.org/) to initiate an OAuth flow for user signin. See the [server.js](https://github.com/reactioncommerce/reaction-next-starterkit/blob/v0.1.0/src/server.js) file for configuration details. For other available libraries that can be used in interacting with the OAuth server, see this [list](https://www.ory.sh/docs/guides/master/hydra/6-how-to/2-architecture#interacting-with-oauth-20).
+The [`reaction-next-starterkit`](https://github.com/reactioncommerce/reaction-next-starterkit/) is configured with [Passport.js](http://www.passportjs.org/) to initiate an OAuth flow for user signin. See the [`server.js`](https://github.com/reactioncommerce/reaction-next-starterkit/blob/v0.1.0/src/server.js) file for configuration details. For other available libraries that can be used in interacting with the OAuth server, see this [list](https://www.ory.sh/docs/guides/master/hydra/6-how-to/2-architecture#interacting-with-oauth-20).
 
 If your OAuth client, the relying party, is a Single-Page Application, consider using the implicit flow and client-side OpenID Connect libraries (example [repo on GitHub](https://github.com/IdentityModel/oidc-client-js)).
 

--- a/website/versioned_sidebars/version-2.0.0-rc.1-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-rc.1-sidebars.json
@@ -27,7 +27,8 @@
       "version-2.0.0-rc.1-recommended-tools",
       "version-2.0.0-rc.1-installation-docker-development",
       "version-2.0.0-rc.1-troubleshooting-development",
-      "version-2.0.0-rc.1-developer-faq"
+      "version-2.0.0-rc.1-developer-faq",
+      "version-2.0.0-rc.1-understanding-hydra-auth-setup"
     ],
     "Swag Shop Tutorial": [
       "version-2.0.0-rc.1-swag-shop-1",


### PR DESCRIPTION
Resolves reactioncommerce/reaction-hydra#6
Type: **docs**

## Changes:
- Adds docs on how Ory Hydra is used as part of Reaction platform services
- Explains how a client configuration is added for the storefront
- Explains how the Identity Provider features work
- Adds links to Hydra Production guides