### PR TITLE
feat: docs for sitemap generator plugin

### DIFF
--- a/public-docs/core-plugins-sitemap-generator.md
+++ b/public-docs/core-plugins-sitemap-generator.md
@@ -1,0 +1,26 @@
+---
+title: Sitemap Generator Plugin (Meteor)
+id: core-plugins-sitemap-generator
+---
+
+A sitemap is an XML file that contains a complete list of URLs for your website that should be accessible by search engines. Having a sitemap.xml file helps Google and other search engines easily discover and index your pages.
+
+Reaction includes a sitemap generator plugin that periodically generates a sitemap.xml file. This process can also be triggered manually through the operator UI.
+
+## Configuration
+
+### Sitemap Refresh Period
+By default, the sitemap generator is set to rebuild the sitemap.xml file every 24 hours. This can be changed by following these steps:
+1. Log in to the Reaction Dashboard
+2. In the sidebar, click "Shop"
+3. Open the "Options" panel
+4. Select an interval in the "Sitemap refresh period" select box. Click "Save changes"
+5. You can also choose to refresh the sitemap now and view it
+
+### Excluding Products from the Sitemap
+By default, all published products are included in the sitemap.xml file. You can choose to exclude products by following these steps:
+1. Log in to the Reaction Dashboard
+2. Navigate to the detail page of the product you would like to exclude
+3. Turn on "Edit mode" from the header
+4. Click the product's title to open up the edit panel
+5. Under "Product settings" uncheck "Include in sitemap"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -41,6 +41,7 @@
     "core-plugins-intro": "Understanding Plugins",
     "core-plugins-marketplace": "Marketplace Plugin (Meteor)",
     "core-plugins-search": "Search Plugins (Meteor)",
+    "core-plugins-sitemap-generator": "Sitemap Generator Plugin (Meteor)",
     "core-plugins-stripe": "Stripe Payment Plugin (Node)",
     "creating-a-theme": "How To: Create a theme for the Meteor UI",
     "creating-test-data-for-meteor-tests": "Creating Test Data for Meteor Tests",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -67,6 +67,7 @@
       "core-plugins-marketplace",
       "core-plugins-search",
       "core-plugins-stripe",
+      "core-plugins-sitemap-generator",
       "community-resources"
     ],
     "Developer How-To": [


### PR DESCRIPTION
Resolves #693 
Impact: **minor**  
Type: **feature**

## Solution
This PR adds documentation for the sitemap generator plugin under the "Core Plugins" section.


## Breaking changes
None

## Testing
1. Confirm "Sitemap Generator Plugin (Meteor)" Appears under "Core Plugins" in the sidebar
2. Read through and confirm docs are accurate