### PR TITLE
Intro Glance broken link fix + discussion starter

### DIFF
--- a/website/versioned_docs/version-2.0.0/intro-glance.md
+++ b/website/versioned_docs/version-2.0.0/intro-glance.md
@@ -20,7 +20,7 @@ Reaction is free. Our code, which is licensed under the GPL v3 license, will alw
 
 ## Installation
 
-Check out our [Installation docs](https://docs.reactioncommerce.com/docs/next/getting-started-developing-with-reaction).
+Check out our [Installation docs](https://docs.reactioncommerce.com/docs/getting-started-developing-with-reaction).
 
 ## Mobile Device Support
 

--- a/website/versioned_docs/version-2.0.0/intro-glance.md
+++ b/website/versioned_docs/version-2.0.0/intro-glance.md
@@ -20,7 +20,7 @@ Reaction is free. Our code, which is licensed under the GPL v3 license, will alw
 
 ## Installation
 
-Check out our [Installation docs](https://docs.reactioncommerce.com/reaction-docs/master/installation).
+Check out our [Installation docs](https://docs.reactioncommerce.com/docs/next/getting-started-developing-with-reaction).
 
 ## Mobile Device Support
 


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

## Issue
[Current link redirects and then 404's](https://docs.reactioncommerce.com/reaction-docs/master/installation) This: https://docs.reactioncommerce.com/docs/installation at first glance seemed next, most logical replacement, yet looks like it is outdated/without left navigation sidebar.

`/next/` subdirectory then seemed the best option at first glance, yet upon closer look - I further understand how these docs are organized and finally [this link seems best replacement](https://docs.reactioncommerce.com/docs/getting-started-developing-with-reaction).

These docs are great, very informative! Just putting this PR out there to fix a very minor issue :)

Thought it worth bringing up/starting a discussion around the multiple redirects and 404's within the docs here. And I do see reasoning behind redirects after looking into this repo more with the versioned docs and pulling from branches, etc. These docs could _even more_ amazing than they already are (and you've set that bar high) with some attention to these internal broken links.