### PR TITLE
How to delegate to remote graphql

### DIFF
--- a/public-docs/how-to-extend-graphql-with-remote-schema.md
+++ b/public-docs/how-to-extend-graphql-with-remote-schema.md
@@ -1,0 +1,82 @@
+---
+title: How To: Extend GraphQL with Remote Schema Delegation
+---
+
+If you have an external service providing a GraphQL interface and you would like to make it available via the main reaction GraphQL API, here's how to do it. For this example, we'll use the public sample Pokemon GraphQL API from `https://graphql-pokemon.now.sh`.
+
+## Export your service's schema
+
+You can use the `get-graphql-schema` command line utility from npm to generate the Schema Definition Language (SDL) text file you need.
+
+```sh
+cat <<EOF | docker run --interactive node bash > pokemon.graphql
+set -eu
+npm install --silent --global get-graphql-schema >/dev/null
+get-graphql-schema "https://graphql-pokemon.now.sh"
+EOF
+```
+
+Incorporate that `pokemon.graphql` file into your plugin's directory structure.
+
+## Load your schema and link your service
+
+In your plugin's `register.js` file, load the schema and use the graphql-tools helper functions to generate a remote schema instance, which your plugin can then provide to reaction.
+
+```js
+import Reaction from "/imports/plugins/core/core/server/Reaction";
+import {
+  makeExecutableSchema,
+  makeRemoteExecutableSchema
+} from "graphql-tools";
+import { HttpLink } from "apollo-link-http";
+import fetch from "node-fetch";
+import schemaSDL from "./pokemon.graphql";
+
+const pokemonUrl = "https://graphql-pokemon.now.sh";
+const link = new HttpLink({ uri: pokemonUrl, fetch });
+const exSchema = makeExecutableSchema({ typeDefs: schemaSDL });
+const remoteSchema = makeRemoteExecutableSchema({ schema: exSchema, link });
+Reaction.registerPackage({
+  label: "Pokemon",
+  name: "pokemon",
+  icon: "fa fa-example",
+  graphQL: {
+    schemas: [remoteSchema]
+  },
+  autoEnable: true,
+  functionsByType: {},
+  settings: {},
+  registry: []
+});
+```
+
+## Verify your queries
+
+Once your plugin is loading properly, you should be able to execute the additional queries from your remote service via the reaction GraphQL endpoint. The queries will be delegated to your service and responses will be merged together.
+
+
+```graphql
+# Submit this query via the reaction graphiql interface to verify
+# the graphql schema delegation is working correctly
+{
+  pokemon(name: "Pikachu") {
+    id
+    name
+    attacks {
+      special {
+        name
+        type
+        damage
+      }
+    }
+    evolutions {
+      id
+      name
+      weight {
+        minimum
+        maximum
+      }
+    }
+  }
+}
+```

--- a/public-docs/how-to-extend-graphql-with-remote-schema.md
+++ b/public-docs/how-to-extend-graphql-with-remote-schema.md
@@ -2,11 +2,11 @@
 title: How To: Extend GraphQL with Remote Schema Delegation
 ---
 
-If you have an external service providing a GraphQL interface and you would like to make it available via the main reaction GraphQL API, here's how to do it. For this example, we'll use the public sample Pokemon GraphQL API from `https://graphql-pokemon.now.sh`.
+If you have an external service providing a GraphQL interface and you would like to make it available via the main Reaction GraphQL API, here's how to do it. For this example, we'll use the [public sample Pokemon GraphQL API](https://github.com/lucasbento/graphql-pokemon) from `https://graphql-pokemon.now.sh`.
 
 ## Export your service's schema
 
-You can use the `get-graphql-schema` command line utility from npm to generate the Schema Definition Language (SDL) text file you need.
+Use the [`get-graphql-schema`](https://www.npmjs.com/package/get-graphql-schema) command line utility from npm to generate the Schema Definition Language (SDL) text file you need.
 
 ```sh
 cat <<EOF | docker run --interactive node bash > pokemon.graphql
@@ -20,7 +20,7 @@ Incorporate that `pokemon.graphql` file into your plugin's directory structure.
 
 ## Load your schema and link your service
 
-In your plugin's `register.js` file, load the schema and use the graphql-tools helper functions to generate a remote schema instance, which your plugin can then provide to reaction.
+In your plugin's `register.js` file, load the schema and use the graphql-tools helper functions to generate a remote schema instance, which your plugin can then provide to Reaction.
 
 ```js
 import Reaction from "/imports/plugins/core/core/server/Reaction";
@@ -52,8 +52,7 @@ Reaction.registerPackage({
 
 ## Verify your queries
 
-Once your plugin is loading properly, you should be able to execute the additional queries from your remote service via the reaction GraphQL endpoint. The queries will be delegated to your service and responses will be merged together.
-
+Once your plugin is loading properly, execute the additional queries from your remote service via the Reaction GraphQL endpoint. The queries will be delegated to your service and responses will be merged together.
 
 ```graphql
 # Submit this query via the reaction graphiql interface to verify

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -87,6 +87,7 @@
     "how-to-create-a-custom-homepage": "Tutorial: Create a custom homepage",
     "how-to-create-a-payment-provider": "How To: Add a Payment Method",
     "how-to-extend-graphql-to-add-field": "How To: Extend GraphQL to add a field",
+    "how-to-extend-graphql-with-remote-schema": "How To: Extend GraphQL with Remote Schema Delegation",
     "how-to-extend-product": "How To: Extend the Product Schema",
     "how-to-get-shop-id-for-client": "How To: Get the shop ID for a client",
     "how-to-rtl": "How To: Add right-to-left language support in the Meteor app",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -80,6 +80,7 @@
       "how-to-add-address-validation-service",
       "how-to-add-tax-service",
       "how-to-extend-graphql-to-add-field",
+      "how-to-extend-graphql-with-remote-schema",
       "how-to-extend-product",
       "register-template",
       "fixtures-images"


### PR DESCRIPTION

Impact: **minor**  
Type: **docs**

This documentation goes with [reaction pull 4870](https://github.com/reactioncommerce/reaction/pull/4870), and describes how a plugin can stitch a remote graphql service into the reaction graphql API. The provided sample files should be a fully-working plugin that developers can deploy and see working locally.

That reaction PR is very likely to see significant churn before it finally merges, so keep that in mind, but starting this PR to show documentation efforts so far.