### PR TITLE
docs: Include description about fallback tax service

### DIFF
--- a/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
+++ b/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
@@ -51,10 +51,12 @@ See below for how to create the two functions.
 Every tax service is expected to register a function that calculates taxes for a single CommonOrder. The core `taxes` plugin calls it like this:
 
 ```js
-const taxServiceResult = await activeTaxService.functions.calculateOrderTaxes({ context, order });
+const taxServiceResult = await primaryTaxService.functions.calculateOrderTaxes({ context, order });
 ```
 
-One or more plugins can provide one or more tax services, so each shop must choose exactly one service (or none) to enable. This is done by an operator in the General Tax Settings panel.
+One or more plugins can provide one or more tax services. Each shop can choose one service as a primary tax service and another as a fallback service. This is done by an operator in the [General Tax Settings panel]((tax.md#enable-a-tax-service)).
+
+> A fallback service is used to calculate the tax when the primary service returns a `null` result. This could be due to errors from the plugin configuration or a network failure. The tax plugin is expected to handle such errors and returns a `null` result when appropriate to allow the fallback service to kick in.
 
 The return from a `calculateOrderTaxes` function is expected to be similar to this:
 

--- a/website/versioned_docs/version-2.0.0/tax.md
+++ b/website/versioned_docs/version-2.0.0/tax.md
@@ -12,7 +12,9 @@ You may use the included tax rates plugin, install a community plugin, or create
 
 1. Open the <i class="rui font-icon fa fa-university"></i> **Tax** panel.
 2. Each tax service may have settings in the panel and/or may require that certain environment variables be set. Before enabling a service, verify that you've properly configured all of this. (For the included "Custom Rates" service, see below.)
-3. Near the top of the tax panel, select a service as the active service for your shop, and click Save.
+3. Near the top of the tax panel, in the `Shop Tax Settings` section, select a service as the primary service for your shop, and click Save. You can optionally select another service to act as a fallback service.
+
+> A fallback service is used to calculate the tax when the primary service returns a `null` result. This could be due to errors from the plugin configuration or a network failure. The tax plugin is expected to handle such errors and returns a `null` result when appropriate to allow the fallback service to kick in.
 
 ## Configure the Custom Rates tax service
 


### PR DESCRIPTION
Resolves: N/A 
Type: **docs**

## What?
Based on the work in reactioncommerce/reaction#4871, this adds a few lines about the new shop tax setting.

Note: I updated the version-2.0.0 files. (Is this the time to update the related public-docs files too?)