### PR TITLE
feat :  add broken link checker to ci process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,18 @@ jobs:
               "$DOCKER_REPOSITORY:$CIRCLE_SHA1" \
               yarn run test
 
+  test-e2e:
+    <<: *defaults
+    steps:
+      - run:
+          name: Install Broken Link Checker
+          command: |
+            yarn add broken-link-checker
+      - run:
+          name: Broken Link Test
+          command: |
+            ./node_modules/.bin/blc ${PROD_URL} -ro -filter=3 -e
+
   snyk-security:
     <<: *defaults
     steps:
@@ -203,3 +215,6 @@ workflows:
               only:
                 - /^staging$/
                 - /^master$/
+      - test-e2e
+          # requires:
+          #   - deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,6 @@ workflows:
               only:
                 - /^staging$/
                 - /^master$/
-      - test-e2e
-          # requires:
-          #   - deploy
+      - test-e2e:
+          requires:
+            - deploy


### PR DESCRIPTION
Resolves #633 
Impact: **minor**  
Type: **test**

## Issue
No CI check for Broken Links on site

## Solution & Screenshots
Implement a broken link checker package and flow within CI only for successful master merges


## Testing
Example Run : 
https://circleci.com/gh/reactioncommerce/reaction-docs/1472
