### PR TITLE
fix: add stance on Windows development support

### DIFF
--- a/public-docs/installation-reaction-platform.md
+++ b/public-docs/installation-reaction-platform.md
@@ -17,11 +17,11 @@ The Reaction Platform is the easiest way to run the entire suite of Reaction ser
 
 1. Requirements:
 
-- Install Docker and Docker Compose ([Mac](https://docs.docker.com/docker-for-mac/install/) | [Windows](https://docs.docker.com/docker-for-windows/install/) | [Linux](https://docs.docker.com/compose/install/#install-compose))
+- Install Docker and Docker Compose ([Mac](https://docs.docker.com/docker-for-mac/install/) | [Linux](https://docs.docker.com/compose/install/#install-compose))
 - Install [Node.js](https://nodejs.org/en/)
 - A GitHub account with a <a href="https://help.github.com/articles/adding-a-new-ssh-key-to-your-github-account/">configured SSH key</a>
 
-> **Windows**: Reaction Platform has not been fully tested on Windows at this time.
+> **Windows**: Reaction Platform does not officially support development on Windows currently. Development on Windows may be possible, but is untested. We are unable to provide support for developers using Windows.
 
 > **Linux**: Docker Compose is included when installing Docker on Mac and Windows, but will need to be installed separately on Linux.
 


### PR DESCRIPTION
Resolves #731 
Impact: **major**  
Type: **docs**

## Issue
Developing Reaction Commerce in a Windows environment has been difficult. Because the development environment is containerized, in theory development in Windows should be straightforward. In practice, there has been difficulty developing in Windows. As we are unable to support development in Windows, we’re updating our installation docs to show that.

We’d like to be able to support development in Windows and plan to revisit the policy when we can spend time troubleshooting the issues that are found in the Windows environment. 

PRs to address issues related to development in the Windows environment are welcomed!

## Solution & Screenshots
Adjust Windows support policy in installation docs. 

## Breaking changes
n/a

## Testing
1. Check that the installation docs reflect our new support policy on Windows as presented by @cshivaratri in #731 