### PR TITLE
docs(addOrderEmail): add method removed note

### DIFF
--- a/public-docs/reaction-orders.md
+++ b/public-docs/reaction-orders.md
@@ -26,7 +26,7 @@ Products.update({
 
 ### orders/addOrderEmail
 
-Called when a customer has checked out as a guest, then adds an email within the order confirmation page. This also adds an email field to `Reaction.Collections.Orders.email`
+Meteor method removed as of [release-2.0.0-rc.7](https://github.com/reactioncommerce/reaction/pull/4815/commits/1de05d5421fa1bafb8a1f543a9d57922cd5734b3)
 
 ### orders/updateHistory
 

--- a/public-docs/reaction-shops.md
+++ b/public-docs/reaction-shops.md
@@ -31,7 +31,7 @@ Meteor.call("shop/getLocale");
 
 ### shop/getCurrencyRates
 
-Meteor method deprecated. Use [this method](https://github.com/reactioncommerce/reaction/pull/4803) instead. 
+Meteor method removed. Use [this method](https://github.com/reactioncommerce/reaction/pull/4803) instead. 
 
 ### shop/flushCurrencyRate
 


### PR DESCRIPTION
Add Meteor method removed, note for `orders/addOrderEmail` and `shop/getCurrencyRates`.