### PR TITLE
rename the GraphQL endpoint to graphql-beta

### DIFF
--- a/public-docs/graphql-developing.md
+++ b/public-docs/graphql-developing.md
@@ -56,7 +56,7 @@ TIP: If you’re confused about where to draw the line, imagine what would have 
 
 ## The Endpoint
 
-The GraphQL server and `/graphql-alpha` endpoint is configured and returned by the `createApolloServer` function, which is called from the `ReactionNodeApp` class and the `TestApp` class for Jest integration tests.
+The GraphQL server and `/graphql-beta` endpoint is configured and returned by the `createApolloServer` function, which is called from the `ReactionNodeApp` class and the `TestApp` class for Jest integration tests.
 
 Newer Reaction code runs within a single `ReactionNodeApp` instance, which is created by Meteor code during app startup. For development and testing purposes, it's also possible to run Reaction as a pure Node app, which also initializes a single `ReactionNodeApp` instance, but without a Meteor context available.
 
@@ -65,7 +65,7 @@ Newer Reaction code runs within a single `ReactionNodeApp` instance, which is cr
 - Builds the `context` object that’s available in all resolver functions. See [The Reaction GraphQL Context](#the-reaction-graphql-context)
 - Formats the `errors` array that is returned to clients, to make errors as helpful as possible
 - Provides the merged GraphQL schema
-- Sets the path as `/graphql-alpha` and exposes a GraphQL Playground for GET requests on `/graphql-alpha`
+- Sets the path as `/graphql-beta` and exposes a GraphQL Playground for GET requests on `/graphql-beta`
 
 ## The Reaction GraphQL Context
 

--- a/public-docs/graphql-intro.md
+++ b/public-docs/graphql-intro.md
@@ -10,7 +10,7 @@ title: Tutorial: Getting started with GraphQL
 
 ## Your first query
 
-To try a simple query, open the GraphQL Playground interface by going to `http://localhost:3000/graphql-alpha` in your browser. This is the same URL that handles GraphQL POST requests, but for GET requests it serves GraphQL Playground.
+To try a simple query, open the GraphQL Playground interface by going to `http://localhost:3000/graphql-beta` in your browser. This is the same URL that handles GraphQL POST requests, but for GET requests it serves GraphQL Playground.
 
 In the left-hand query box, enter the following:
 

--- a/public-docs/graphql-using.md
+++ b/public-docs/graphql-using.md
@@ -5,7 +5,7 @@ title: Using the GraphQL API
 
 ## Reaction GraphQL Implementation
 
-Reaction GraphQL is accessible at `/graphql-alpha` when running the Meteor app. You can also access it without running the Meteor app by running a Node Express server.
+Reaction GraphQL is accessible at `/graphql-beta` when running the Meteor app. You can also access it without running the Meteor app by running a Node Express server.
 
 To run the full Meteor app from a local checkout:
 
@@ -19,7 +19,7 @@ To run the Node Express server only from a local checkout:
 npm run devserver
 ```
 
-If your Reaction shop is already hosted somewhere, just POST to /graphql-alpha at that URL to use GraphQL.
+If your Reaction shop is already hosted somewhere, just POST to /graphql-beta at that URL to use GraphQL.
 
 The GraphQL server is implemented using [Apollo Server](https://www.apollographql.com/docs/apollo-server/). It is compatible with [Apollo Client](https://www.apollographql.com/docs/react/) or [Relay Modern](https://facebook.github.io/relay/) for client development.
 
@@ -32,7 +32,7 @@ We recommend using a standalone GraphQL client to connect and make requests. Her
 
 ### Making Queries
 
-As long as you use POST method (not GET) and use the `/graphql-alpha` path as the URL, requests from any GraphQL client should work. Many queries and mutations will check identity and authorization, and therefore require you to send a bearer token along with your request. Standalone GraphQL clients have a “Headers” option where you can specify this manually. See [Identity and Authorization](#identity-and-authorization).
+As long as you use POST method (not GET) and use the `/graphql-beta` path as the URL, requests from any GraphQL client should work. Many queries and mutations will check identity and authorization, and therefore require you to send a bearer token along with your request. Standalone GraphQL clients have a “Headers” option where you can specify this manually. See [Identity and Authorization](#identity-and-authorization).
 
 ## Identity and Authorization
 

--- a/public-docs/installation-reaction-platform.md
+++ b/public-docs/installation-reaction-platform.md
@@ -93,8 +93,8 @@ docker-compose logs -f
 
 | Directory: Service                                                                         | URL                                                           |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [POST localhost:3000/graphql-alpha](localhost:3000/graphql-alpha) |
-| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API playground         | [GET localhost:3000/graphql-alpha](localhost:3000/graphql-alpha)            |
+| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [POST localhost:3000/graphql-beta](localhost:3000/graphql-beta) |
+| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API playground         | [GET localhost:3000/graphql-beta](localhost:3000/graphql-beta)            |
 | [`reaction`](https://github.com/reactioncommerce/reaction): Classic UI                     | [localhost:3000](localhost:3000)                              |
 | [`reaction`](https://github.com/reactioncommerce/reaction): MongoDB                        | [localhost:27017](localhost:27017)                            |
 | [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra): oryd/hydra         | [localhost:4444](localhost:4444)                              |

--- a/public-docs/storefront-apollo-client.md
+++ b/public-docs/storefront-apollo-client.md
@@ -7,7 +7,7 @@ This article is part of the [Storefront UI Development Guide](./storefront-intro
 - Previous Task: *None*
 - Next Task: [Build a product listing page](./storefront-product-listing-page.md)
 
-To add Apollo Client to your UI app, read the [excellent Apollo docs](https://www.apollographql.com/docs/react/essentials/get-started.html). For local development, the Reaction GraphQL endpoint `uri` is `http://localhost:3000/graphql-alpha`, but we recommend storing that value in app config where it can be set differently per environment.
+To add Apollo Client to your UI app, read the [excellent Apollo docs](https://www.apollographql.com/docs/react/essentials/get-started.html). For local development, the Reaction GraphQL endpoint `uri` is `http://localhost:3000/graphql-beta`, but we recommend storing that value in app config where it can be set differently per environment.
 
 For your test query, try this:
 
@@ -26,7 +26,7 @@ client
   .then(result => console.log(result));
 ```
 
-> If it doesn't work in your storefront UI code, try it directly in the GraphQL Playground at http://localhost:3000/graphql-alpha. If it works there, then check over your Apollo Client setup code again and check for any errors.
+> If it doesn't work in your storefront UI code, try it directly in the GraphQL Playground at http://localhost:3000/graphql-beta. If it works there, then check over your Apollo Client setup code again and check for any errors.
 
 Assuming your test query works, you're ready to start building your storefront UI. You will eventually need to configure authentication, but most of a storefront UI can be built without authenticating, so we'll do that later.
 

--- a/website/versioned_docs/version-2.0.0/graphql-developing.md
+++ b/website/versioned_docs/version-2.0.0/graphql-developing.md
@@ -57,7 +57,7 @@ TIP: If you’re confused about where to draw the line, imagine what would have 
 
 ## The Endpoint
 
-The GraphQL server and `/graphql-alpha` endpoint is configured and returned by the `createApolloServer` function, which is called from the `ReactionNodeApp` class and the `TestApp` class for Jest integration tests.
+The GraphQL server and `/graphql-beta` endpoint is configured and returned by the `createApolloServer` function, which is called from the `ReactionNodeApp` class and the `TestApp` class for Jest integration tests.
 
 Newer Reaction code runs within a single `ReactionNodeApp` instance, which is created by Meteor code during app startup. For development and testing purposes, it's also possible to run Reaction as a pure Node app, which also initializes a single `ReactionNodeApp` instance, but without a Meteor context available.
 
@@ -66,7 +66,7 @@ Newer Reaction code runs within a single `ReactionNodeApp` instance, which is cr
 - Builds the `context` object that’s available in all resolver functions. See [The Reaction GraphQL Context](#the-reaction-graphql-context)
 - Formats the `errors` array that is returned to clients, to make errors as helpful as possible
 - Provides the merged GraphQL schema
-- Sets the path as `/graphql-alpha` and exposes a GraphQL Playground for GET requests on `/graphql-alpha`
+- Sets the path as `/graphql-beta` and exposes a GraphQL Playground for GET requests on `/graphql-beta`
 
 ## The Reaction GraphQL Context
 

--- a/website/versioned_docs/version-2.0.0/graphql-intro.md
+++ b/website/versioned_docs/version-2.0.0/graphql-intro.md
@@ -11,7 +11,7 @@ original_id: graphql-intro
 
 ## Your first query
 
-To try a simple query, open the GraphQL Playground interface by going to `http://localhost:3000/graphql-alpha` in your browser. This is the same URL that handles GraphQL POST requests, but for GET requests it serves GraphQL Playground.
+To try a simple query, open the GraphQL Playground interface by going to `http://localhost:3000/graphql-beta` in your browser. This is the same URL that handles GraphQL POST requests, but for GET requests it serves GraphQL Playground.
 
 In the left-hand query box, enter the following:
 

--- a/website/versioned_docs/version-2.0.0/graphql-using.md
+++ b/website/versioned_docs/version-2.0.0/graphql-using.md
@@ -6,7 +6,7 @@ original_id: graphql-using
 
 ## Reaction GraphQL Implementation
 
-Reaction GraphQL is accessible at `/graphql-alpha` when running the Meteor app. You can also access it without running the Meteor app by running a Node Express server.
+Reaction GraphQL is accessible at `/graphql-beta` when running the Meteor app. You can also access it without running the Meteor app by running a Node Express server.
 
 To run the full Meteor app from a local checkout:
 
@@ -20,7 +20,7 @@ To run the Node Express server only from a local checkout:
 npm run devserver
 ```
 
-If your Reaction shop is already hosted somewhere, just POST to /graphql-alpha at that URL to use GraphQL.
+If your Reaction shop is already hosted somewhere, just POST to /graphql-beta at that URL to use GraphQL.
 
 The GraphQL server is implemented using [Apollo Server](https://www.apollographql.com/docs/apollo-server/). It is compatible with [Apollo Client](https://www.apollographql.com/docs/react/) or [Relay Modern](https://facebook.github.io/relay/) for client development.
 
@@ -33,7 +33,7 @@ We recommend using a standalone GraphQL client to connect and make requests. Her
 
 ### Making Queries
 
-As long as you use POST method (not GET) and use the `/graphql-alpha` path as the URL, requests from any GraphQL client should work. Many queries and mutations will check identity and authorization, and therefore require you to send a bearer token along with your request. Standalone GraphQL clients have a “Headers” option where you can specify this manually. See [Identity and Authorization](#identity-and-authorization).
+As long as you use POST method (not GET) and use the `/graphql-beta` path as the URL, requests from any GraphQL client should work. Many queries and mutations will check identity and authorization, and therefore require you to send a bearer token along with your request. Standalone GraphQL clients have a “Headers” option where you can specify this manually. See [Identity and Authorization](#identity-and-authorization).
 
 ## Identity and Authorization
 

--- a/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
+++ b/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
@@ -94,8 +94,8 @@ docker-compose logs -f
 
 | Directory: Service                                                                         | URL                                                           |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [POST localhost:3000/graphql-alpha](localhost:3000/graphql-alpha) |
-| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API playground         | [GET localhost:3000/graphql-alpha](localhost:3000/graphql-alpha)            |
+| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API                    | [POST localhost:3000/graphql-beta](localhost:3000/graphql-beta) |
+| [`reaction`](https://github.com/reactioncommerce/reaction): GraphQL API playground         | [GET localhost:3000/graphql-beta](localhost:3000/graphql-beta)            |
 | [`reaction`](https://github.com/reactioncommerce/reaction): Classic UI                     | [localhost:3000](localhost:3000)                              |
 | [`reaction`](https://github.com/reactioncommerce/reaction): MongoDB                        | [localhost:27017](localhost:27017)                            |
 | [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra): oryd/hydra         | [localhost:4444](localhost:4444)                              |

--- a/website/versioned_docs/version-2.0.0/storefront-apollo-client.md
+++ b/website/versioned_docs/version-2.0.0/storefront-apollo-client.md
@@ -8,7 +8,7 @@ This article is part of the [Storefront UI Development Guide](./storefront-intro
 - Previous Task: *None*
 - Next Task: [Build a product listing page](./storefront-product-listing-page.md)
 
-To add Apollo Client to your UI app, read the [excellent Apollo docs](https://www.apollographql.com/docs/react/essentials/get-started.html). For local development, the Reaction GraphQL endpoint `uri` is `http://localhost:3000/graphql-alpha`, but we recommend storing that value in app config where it can be set differently per environment.
+To add Apollo Client to your UI app, read the [excellent Apollo docs](https://www.apollographql.com/docs/react/essentials/get-started.html). For local development, the Reaction GraphQL endpoint `uri` is `http://localhost:3000/graphql-beta`, but we recommend storing that value in app config where it can be set differently per environment.
 
 For your test query, try this:
 
@@ -27,7 +27,7 @@ client
   .then(result => console.log(result));
 ```
 
-> If it doesn't work in your storefront UI code, try it directly in the GraphQL Playground at http://localhost:3000/graphql-alpha. If it works there, then check over your Apollo Client setup code again and check for any errors.
+> If it doesn't work in your storefront UI code, try it directly in the GraphQL Playground at http://localhost:3000/graphql-beta. If it works there, then check over your Apollo Client setup code again and check for any errors.
 
 Assuming your test query works, you're ready to start building your storefront UI. You will eventually need to configure authentication, but most of a storefront UI can be built without authenticating, so we'll do that later.
 


### PR DESCRIPTION
As preparation for the 2.0 release of Reaction, the GraphQL endpoint has been renamed to `graphql-beta` to indicate increased stability.