### PR TITLE
2.0 docs updates

### DIFF
--- a/public-docs/creating-a-theme.md
+++ b/public-docs/creating-a-theme.md
@@ -28,9 +28,6 @@ Reaction.registerPackage({
   // Icon for toolbars
   icon: "fa fa-bars",
 
-  // Auto-enable plugin, sets enabled: true in database
-  autoEnable: true,
-
   // Settings for plugin
   settings: {},
 

--- a/public-docs/dev-how-do-i.md
+++ b/public-docs/dev-how-do-i.md
@@ -146,7 +146,6 @@ Reaction.registerPackage({
   label: "Shipping",
   name: "reaction-shipping",
   icon: "fa fa-truck",
-  autoEnable: true,
   functionsByType: {
     startup: [startup]
   }

--- a/public-docs/dev-how-do-i.md
+++ b/public-docs/dev-how-do-i.md
@@ -140,17 +140,18 @@ Then import and register the startup function in the plugin's `register.js` file
 
 ```js
 import Reaction from "/imports/plugins/core/core/server/Reaction";
-import startup from "./server/no-meteor/startup";
 
-Reaction.registerPackage({
-  label: "Shipping",
-  name: "reaction-shipping",
-  icon: "fa fa-truck",
-  functionsByType: {
-    startup: [startup]
-  }
-  // other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Shipping",
+    name: "reaction-shipping",
+    icon: "fa fa-truck",
+    functionsByType: {
+      startup: [startup]
+    }
+    // other props
+  });
+}
 ```
 
 ## Emit an app event

--- a/public-docs/graphql-create-mutation.md
+++ b/public-docs/graphql-create-mutation.md
@@ -35,15 +35,16 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Step 4: Create the plugin mutation file
@@ -78,16 +79,17 @@ export default {
 };
 ```
 
-If this is the first mutation for the plugin, you'll also need to pass the full `mutations` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first mutation for the plugin, you'll also need to pass the full `mutations` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
 import mutations from "./server/no-meteor/mutations";
 
-Reaction.registerPackage({
-  mutations,
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    mutations,
+    // other props
+  });
+}
 ```
 
 Your plugin mutation function is now available in the GraphQL context as `context.mutations.createSomething`.
@@ -167,20 +169,21 @@ export default {
 };
 ```
 
-Then pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+Then pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 Calling your mutation with GraphQL should now work.

--- a/public-docs/graphql-create-query.md
+++ b/public-docs/graphql-create-query.md
@@ -34,15 +34,16 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Step 4: Create the plugin query file
@@ -77,16 +78,17 @@ export default {
 };
 ```
 
-If this is the first query for the plugin, you'll also need to pass the full `queries` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first query for the plugin, you'll also need to pass the full `queries` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
 import queries from "./server/no-meteor/queries";
 
-Reaction.registerPackage({
-  queries,
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    queries,
+    // other props
+  });
+}
 ```
 
 Your plugin query function is now available in the GraphQL context as `context.queries.widgets`.
@@ -171,20 +173,21 @@ export default {
 };
 ```
 
-Then pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+Then pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 Calling your query with GraphQL should now work.

--- a/public-docs/graphql-developing.md
+++ b/public-docs/graphql-developing.md
@@ -117,7 +117,27 @@ For the GraphQL endpoint, we have an Express middleware function that looks for 
 
 ## IDs in GraphQL
 
-All IDs are exposed in GraphQL as globally unique IDs. To convert internal IDs to opaque UUIDs, we first prefix them with "reaction/\<namespace\>" and then base64 encode them. The primary transformation functions that handle this are in `/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/id.js`, but there are namespace-specific utility functions in that `xforms` folder that are usually a better choice.
+All IDs are exposed in GraphQL as globally unique IDs on fields named `_id`. When we finalize the GraphQL API, we may change this field name to `id`, which is more commonly used in the GraphQL world.
+
+The GraphQL server specification has no opinion on what a type's ID field should look like, but it does provide [a built-in ID type](https://graphql.github.io/graphql-spec/draft/#sec-ID).
+
+> The ID scalar type represents a unique identifier, often used to refetch an object or as the key for a cache. The ID type is serialized in the same way as a String; however, it is not intended to be human‐readable. While it is often numeric, it should always serialize as a String.
+
+In particular, note that "it is not intended to be human‐readable". You should never display a field of type `ID` anywhere. They are only for references. If your data comes over from another system and has IDs with some meaning, then you should also store them on a different field where the raw value will not be obfuscated by the GraphQL layer.
+
+Note also that the server specification does not necessarily care whether an ID is globally unique. However, we intend compatibility with both Relay and Apollo for client-side frameworks, and [the Relay specification](https://facebook.github.io/relay/graphql/objectidentification.htm#sec-Node-Interface) does have a requirement here:
+
+> This `id` should be a globally unique identifier for this object, and given just this `id`, the server should be able to refetch the object.
+
+Additionally, the [Apollo caching docs](https://www.apollographql.com/docs/react/advanced/caching/#normalization) have this to say:
+
+> By default, InMemoryCache will attempt to use the commonly found primary keys of `id` and `_id` for the unique identifier if they exist
+
+This does not specifically require global uniqueness since it also uses `__typename`, but because Relay does, we've opted to ensure IDs are globally unique.
+
+In most cases, actual internal data IDs are in MongoDB collections, so they are guaranteed unique within the collection, but not among all collections. To add that extra layer of uniqueness, we concatenate the namespace with the internal ID, and then to keep it looking like a "not human‐readable" ID, we base64 encode.
+
+To convert internal IDs to opaque UUIDs, we first prefix them with "reaction/\<namespace\>" and then base64 encode them. The primary transformation functions that handle this are in `/imports/plugins/core/graphql/server/no-meteor/resolvers/xforms/id.js`, but there are namespace-specific utility functions in that `xforms` folder that are usually a better choice.
 
 The GraphQL resolver functions are the place where ID encoding and decoding happens. They then call out to plugin functions that deal exclusively with internal IDs. Any IDs returned by such functions must also be transformed before returning them, although this typically and preferably happens in a type resolver.
 

--- a/public-docs/graphql-resolvers-file-structure.md
+++ b/public-docs/graphql-resolvers-file-structure.md
@@ -32,17 +32,18 @@ export default {
 You could save that file as `resolvers.js` in `/server/no-meteor` in the payments plugin, and then import it and register it:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 While that would work and may even be fine for a simple custom plugin, there are some downsides. We want to be able to test each complex resolver function, which is easier if each function is in its own file. Also, plugins typically keep growing, so our single file might become too large to easily understand over time.

--- a/public-docs/how-to-add-address-validation-service.md
+++ b/public-docs/how-to-add-address-validation-service.md
@@ -24,7 +24,6 @@ import addressValidation from "./server/addressValidation.js";
 Reaction.registerPackage({
   label: "Great Validation Service",
   name: "great-validation-service",
-  autoEnable: true,
   addressValidationServices: [
     {
       displayName: "Great Validation",

--- a/public-docs/how-to-add-address-validation-service.md
+++ b/public-docs/how-to-add-address-validation-service.md
@@ -15,27 +15,28 @@ In general, to add an address validation service you must do the following:
 
 ### Register an address validation service
 
-Address validation services are registered by passing an array of them to the `addressValidationServices` property of the `Reaction.registerPackage` options.
+Address validation services are registered by passing an array of them to the `addressValidationServices` property of the `registerPlugin` options.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import addressValidation from "./server/addressValidation.js";
+import addressValidation from "./addressValidation.js";
 
-Reaction.registerPackage({
-  label: "Great Validation Service",
-  name: "great-validation-service",
-  addressValidationServices: [
-    {
-      displayName: "Great Validation",
-      functions: {
-        addressValidation
-      },
-      name: "great",
-      supportedCountryCodes: ["US", "CA", "DE", "IN"]
-    }
-  ]
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Great Validation Service",
+    name: "great-validation-service",
+    addressValidationServices: [
+      {
+        displayName: "Great Validation",
+        functions: {
+          addressValidation
+        },
+        name: "great",
+        supportedCountryCodes: ["US", "CA", "DE", "IN"]
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `addressValidationServices` property is the key to making your plugin

--- a/public-docs/how-to-add-tax-service.md
+++ b/public-docs/how-to-add-tax-service.md
@@ -17,28 +17,29 @@ In general, to add a tax service you must do the following:
 
 ### Register a tax service
 
-Tax services are registered by passing an array of them to the `taxServices` property of the `Reaction.registerPackage` options.
+Tax services are registered by passing an array of them to the `taxServices` property of the `registerPlugin` options.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import calculateOrderTaxes from "./server/no-meteor/util/calculateOrderTaxes";
-import getTaxCodes from "./server/no-meteor/util/getTaxCodes";
+import calculateOrderTaxes from "./util/calculateOrderTaxes";
+import getTaxCodes from "./util/getTaxCodes";
 
-Reaction.registerPackage({
-  label: "Custom Rates",
-  name: "reaction-taxes-rates",
-  taxServices: [
-    {
-      displayName: "Custom Rates",
-      name: "custom-rates",
-      functions: {
-        calculateOrderTaxes,
-        getTaxCodes
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Custom Rates",
+    name: "reaction-taxes-rates",
+    taxServices: [
+      {
+        displayName: "Custom Rates",
+        name: "custom-rates",
+        functions: {
+          calculateOrderTaxes,
+          getTaxCodes
+        }
       }
-    }
-  ]
-  // ...
-});
+    ]
+    // other props
+  });
+}
 ```
 
 See below for how to create the two functions.

--- a/public-docs/how-to-add-tax-service.md
+++ b/public-docs/how-to-add-tax-service.md
@@ -27,7 +27,6 @@ import getTaxCodes from "./server/no-meteor/util/getTaxCodes";
 Reaction.registerPackage({
   label: "Custom Rates",
   name: "reaction-taxes-rates",
-  autoEnable: true,
   taxServices: [
     {
       displayName: "Custom Rates",

--- a/public-docs/how-to-create-a-fulfillment-methods-plugin.md
+++ b/public-docs/how-to-create-a-fulfillment-methods-plugin.md
@@ -70,7 +70,6 @@ import getFulfillmentMethodsWithQuotes from "./server/getFulfillmentMethodsWithQ
 Reaction.registerPackage({
   label: "My Fulfillment Plugin",
   name: "my-fulfillment-plugin",
-  autoEnable: true,
   functionsByType: {
     getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
   },

--- a/public-docs/how-to-create-a-fulfillment-methods-plugin.md
+++ b/public-docs/how-to-create-a-fulfillment-methods-plugin.md
@@ -11,7 +11,7 @@ In general, to add a fulfillment method you must do the following:
 - Create a new plugin
 - Create a `getFulfillmentMethodsWithQuotes` function in your plugin
 - Create a React component for operators to enter and edit fulfillment method details, unless they'll be managed in an external system
-- Register the function and the React components using your plugin's `registerPackage` call
+- Register the function and the React components using your plugin's `registerPlugin` call
 
 Reaction ships with one such plugin, `shipping-rates`, which you can look at for inspiration. You will want to remove that plugin if adding your own, unless you're combining multiple fulfillment method sources
 
@@ -65,16 +65,18 @@ Everything needs to be registered to be seen by Reaction core.
 Pass your function in the `functionsByType` list:
 
 ```js
-import getFulfillmentMethodsWithQuotes from "./server/getFulfillmentMethodsWithQuotes";
+import getFulfillmentMethodsWithQuotes from "./getFulfillmentMethodsWithQuotes";
 
-Reaction.registerPackage({
-  label: "My Fulfillment Plugin",
-  name: "my-fulfillment-plugin",
-  functionsByType: {
-    getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
-  },
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "My Fulfillment Plugin",
+    name: "my-fulfillment-plugin",
+    functionsByType: {
+      getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
+    },
+    // other props
+  });
+}
 ```
 
 ### Settings UI
@@ -82,17 +84,19 @@ Reaction.registerPackage({
 If your plugin needs any settings that it will not get from environment variables, register the React component in the `registry` array:
 
 ```js
-Reaction.registerPackage({
-  // ...
-  registry: [
-    {
-      label: "My Fulfillment Plugin",
-      provides: ["shippingSettings"],
-      container: "dashboard",
-      template: "MyFulfillmentPluginSettings"
-    }
-  ]
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    registry: [
+      {
+        label: "My Fulfillment Plugin",
+        provides: ["shippingSettings"],
+        container: "dashboard",
+        template: "MyFulfillmentPluginSettings"
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `label` is shown in the operator UI to group the settings for each fulfillment plugin. The `provides` property must be an array containing `"shippingSettings"`. Set `template` to the name of your React component, which you must register with `registerComponent` in client code.

--- a/public-docs/how-to-create-a-payment-provider.md
+++ b/public-docs/how-to-create-a-payment-provider.md
@@ -180,7 +180,6 @@ Reaction.registerPackage({
   label: "Stripe",
   name: "reaction-stripe",
   icon: "fa fa-cc-stripe",
-  autoEnable: true,
   paymentMethods: [{
     name: "stripe_card",
     displayName: "Stripe Card",

--- a/public-docs/how-to-create-a-payment-provider.md
+++ b/public-docs/how-to-create-a-payment-provider.md
@@ -14,7 +14,7 @@ In general, to add a payment method you must do the following:
 - Add routes for callback URLs if necessary
 - Create a React component for collecting any necessary payment data
 - Create a React component for operators to enter and edit necessary settings for your payment method
-- Register the method definition, its functions, the routes, and the React components using your plugin's `registerPackage` call
+- Register the method definition, its functions, the routes, and the React components using your plugin's `registerPlugin` call
 
 There are two included plugins (in `/imports/plugins/included`) that provide payment methods, which you can look at for inspiration:
 - payments-example
@@ -114,7 +114,7 @@ You are expected to return a valid payment object similar to this:
 Be sure that:
 - the `mode` is "authorize"
 - the `status` is "created"
-- the `name` matches the method name you specified in `registerPackage` and in the GraphQL `PaymentMethodName` enum
+- the `name` matches the method name you specified in `registerPlugin` and in the GraphQL `PaymentMethodName` enum
 - `amount` matches what was passed in
 - All required properties are present
 
@@ -171,28 +171,30 @@ If you followed [How To: Create a new GraphQL mutation](./graphql-create-mutatio
 Here's an example of how to register the payment methods your plugin provides:
 
 ```js
-import stripeCapturePayment from "./server/no-meteor/util/stripeCapturePayment";
-import stripeCreateAuthorizedPayment from "./server/no-meteor/util/stripeCreateAuthorizedPayment";
-import stripeCreateRefund from "./server/no-meteor/util/stripeCreateRefund";
-import stripeListRefunds from "./server/no-meteor/util/stripeListRefunds";
+import stripeCapturePayment from "./util/stripeCapturePayment";
+import stripeCreateAuthorizedPayment from "./util/stripeCreateAuthorizedPayment";
+import stripeCreateRefund from "./util/stripeCreateRefund";
+import stripeListRefunds from "./util/stripeListRefunds";
 
-Reaction.registerPackage({
-  label: "Stripe",
-  name: "reaction-stripe",
-  icon: "fa fa-cc-stripe",
-  paymentMethods: [{
-    name: "stripe_card",
-    displayName: "Stripe Card",
-    canRefund: true,
-    functions: {
-      capturePayment: stripeCapturePayment,
-      createAuthorizedPayment: stripeCreateAuthorizedPayment,
-      createRefund: stripeCreateRefund,
-      listRefunds: stripeListRefunds
-    }
-  }],
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Stripe",
+    name: "reaction-stripe",
+    icon: "fa fa-cc-stripe",
+    paymentMethods: [{
+      name: "stripe_card",
+      displayName: "Stripe Card",
+      canRefund: true,
+      functions: {
+        capturePayment: stripeCapturePayment,
+        createAuthorizedPayment: stripeCreateAuthorizedPayment,
+        createRefund: stripeCreateRefund,
+        listRefunds: stripeListRefunds
+      }
+    }],
+    // other props
+  });
+}
 ```
 
 Each object in `paymentMethods` must have a `name` and `displayName`.
@@ -208,17 +210,19 @@ The `canRefund` option is `true` by default, but if your method does not support
 If your plugin needs any settings that it will not get from environment variables, register the React component in the `registry` array:
 
 ```js
-Reaction.registerPackage({
-  // ...
-  registry: [
-    {
-      label: "Acme Payments",
-      provides: ["paymentSettings"],
-      container: "dashboard",
-      template: "AcmePaymentsPluginSettings"
-    }
-  ]
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    registry: [
+      {
+        label: "Acme Payments",
+        provides: ["paymentSettings"],
+        container: "dashboard",
+        template: "AcmePaymentsPluginSettings"
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `label` is shown in the operator UI to group the settings for each payment plugin. The `provides` property must be an array containing `"paymentSettings"`. Set `template` to the name of your React component, which you must register with `registerComponent` in client code.

--- a/public-docs/how-to-extend-graphql-to-add-field.md
+++ b/public-docs/how-to-extend-graphql-to-add-field.md
@@ -31,15 +31,16 @@ Sometimes you only need to extend GraphQL to add a field to an existing type. He
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Create a field resolver if necessary
@@ -75,20 +76,21 @@ export default {
 };
 ```
 
-If this is the first resolver for the plugin, pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first resolver for the plugin, pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 You should now be able to query for your custom field using GraphQL.

--- a/public-docs/how-to-extend-graphql-with-remote-schema.md
+++ b/public-docs/how-to-extend-graphql-with-remote-schema.md
@@ -43,7 +43,6 @@ Reaction.registerPackage({
   graphQL: {
     schemas: [remoteSchema]
   },
-  autoEnable: true,
   functionsByType: {},
   settings: {},
   registry: []

--- a/public-docs/how-to-extend-graphql-with-remote-schema.md
+++ b/public-docs/how-to-extend-graphql-with-remote-schema.md
@@ -23,7 +23,6 @@ Incorporate that `pokemon.graphql` file into your plugin's directory structure.
 In your plugin's `register.js` file, load the schema and use the graphql-tools helper functions to generate a remote schema instance, which your plugin can then provide to Reaction.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
 import {
   makeExecutableSchema,
   makeRemoteExecutableSchema
@@ -36,17 +35,18 @@ const pokemonUrl = "https://graphql-pokemon.now.sh";
 const link = new HttpLink({ uri: pokemonUrl, fetch });
 const exSchema = makeExecutableSchema({ typeDefs: schemaSDL });
 const remoteSchema = makeRemoteExecutableSchema({ schema: exSchema, link });
-Reaction.registerPackage({
-  label: "Pokemon",
-  name: "pokemon",
-  icon: "fa fa-example",
-  graphQL: {
-    schemas: [remoteSchema]
-  },
-  functionsByType: {},
-  settings: {},
-  registry: []
-});
+
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Pokemon",
+    name: "pokemon",
+    icon: "fa fa-example",
+    graphQL: {
+      schemas: [remoteSchema]
+    }
+    // other props
+  });
+}
 ```
 
 ## Verify your queries

--- a/public-docs/how-to-extend-product.md
+++ b/public-docs/how-to-extend-product.md
@@ -68,18 +68,18 @@ Refer to [How To: Extend GraphQL to add a field](./how-to-extend-graphql-to-add-
 
 *Skip this step if your property is not needed in the published catalog*
 
-A plugin can include a `catalog` object in `registerPackage`, with `customPublishedProductFields` and `customPublishedProductVariantFields` that are set to arrays of property names. These will be appended to the core list of fields for which published status should be tracked. This is used to build the hashes that are used to display an indicator when changes need to be published.
+A plugin can include a `catalog` object in `registerPlugin`, with `customPublishedProductFields` and `customPublishedProductVariantFields` that are set to arrays of property names. These will be appended to the core list of fields for which published status should be tracked. This is used to build the hashes that are used to display an indicator when changes need to be published.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-Reaction.registerPackage({
-  catalog: {
-    customPublishedProductFields: ["myProperty"],
-    customPublishedProductVariantFields: ["myProperty"]
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    catalog: {
+      customPublishedProductFields: ["myProperty"],
+      customPublishedProductVariantFields: ["myProperty"]
+    },
+    // other props
+  });
+}
 ```
 
 ### Register a function that publishes custom property
@@ -87,15 +87,16 @@ Reaction.registerPackage({
 *Skip this step if your property is not needed in the published catalog*
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import publishProductToCatalog from "./server/no-meteor/publishProductToCatalog";
+import publishProductToCatalog from "./publishProductToCatalog";
 
-Reaction.registerPackage({
-  functionsByType: {
-    publishProductToCatalog: [publishProductToCatalog]
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    functionsByType: {
+      publishProductToCatalog: [publishProductToCatalog]
+    },
+    // other props
+  });
+}
 ```
 
 Where the `publishProductToCatalog` function looks something like this:

--- a/public-docs/how-to-store-custom-order-fields.md
+++ b/public-docs/how-to-store-custom-order-fields.md
@@ -47,7 +47,7 @@ const order = {
 ```
 
 ## Transforming or Adding Custom Order Fields on the Server
-Whether or not you've allowed clients to send additional order data, you can also provide a function that returns custom order fields on the server. Do this using the `functionsByType` option in `registerPackage`:
+Whether or not you've allowed clients to send additional order data, you can also provide a function that returns custom order fields on the server. Do this using the `functionsByType` option in `registerPlugin`:
 
 ```js
 functionsByType: {

--- a/public-docs/installation-reaction-platform.md
+++ b/public-docs/installation-reaction-platform.md
@@ -25,7 +25,9 @@ The Reaction Platform is the easiest way to run the entire suite of Reaction ser
 
 > **Linux**: Docker Compose is included when installing Docker on Mac and Windows, but will need to be installed separately on Linux.
 
-2. Before you get started, make sure you are not running any applications on the default ports: `3000`, `4000`, `4444`, `4445`, `5555`, `5432`, and `27017`.
+2. Before you get started:
+  - Increase the memory and CPU allocated to Docker in the Docker settings. We recommend at least 4 GiB memory. The default values are usually not sufficient to run the full Reaction system. See the [troubleshooting-development](./troubleshooting-development#memory-errors-or-errors-about-meteor-rawlogs) article for more information.
+  - Make sure you are not running any applications on the default ports: `3000`, `4000`, `4444`, `4445`, `5555`, `5432`, and `27017`.
 
 3. Clone [**Reaction Platform**](https://github.com/reactioncommerce/reaction-platform)
 

--- a/public-docs/permissions.md
+++ b/public-docs/permissions.md
@@ -3,59 +3,7 @@ id: permissions
 title: Permissions
 ---
 
-The [alanning:roles](https://github.com/alanning/meteor-roles) package provides Reaction permissions support.
-
-## Packages
-
-### Permissions are grouped by `shopId`
-
-Package specific roles can be defined in `register.js`, by adding custom permissions to registry entries with:
-
-```js
-  permissions: [
-    {
-      label: "Custom Permission"
-      permission: "custom/permission"
-    }
-  ]
-```
-
-Permission of the current route and user are compared against the package route by default, adding specific permissions to the registry entry is optional.
-
-For using shop permissions in some packages you must add it into register directive. If we add this package then permissions will be available in Shop Accounts Settings.
-
-Another example:
-
-```js
-import { Reaction } from "/server/api";
-
-Reaction.registerPackage({
-  label: "Dashboard",
-  name: "reaction-dashboard",
-  icon: "fa fa-th",
-  settings: {
-    name: "Dashboard"
-  },
-  registry: [{
-    provides: "dashboard",
-    workflow: "coreDashboardWorkflow",
-    template: "dashboardPackages",
-    name: "dashboardPackages",
-    label: "Core",
-    description: "Reaction core shop configuration",
-    icon: "fa fa-th",
-    priority: 0,
-    container: "core",
-    permissions: [{
-      label: "Dashboard",
-      permission: "dashboard"
-    }]
-   });
-```
-
-At the point where Packages are published in the app, each registry item permissions are collected and put on the
-package registry [(source)](https://github.com/reactioncommerce/reaction/blob/master/server/publications/collections/packages.js#L31-L56).
-Based on these permissions, we can enable or disable functionality depending on user roles.
+The [alanning:roles](https://github.com/alanning/meteor-roles) Meteor package provides Reaction permissions support.
 
 ## Owner
 
@@ -63,138 +11,46 @@ The initial setup user was added to the shops 'owner' permission group with the 
 
 Users with "owner" role are full-permission, app-wide users.
 
-**To check if user has owner access:**
+**To check if user has owner access in browser code:**
 
 ```js
-    # client / server
-    import Logger from "@reactioncommerce/logger";
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
+import Logger from "@reactioncommerce/logger";
+import { Reaction } from "/client/api";
 
-    if ( Reaction.hasOwnerAccess() ) {
-      Logger.info("The Reaction user has Owner Access");
-    }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasOwnerAccess` helper.
-
-```html
-    # template
-    {{#if hasOwnerAccess}}
-      <strong>This has owner access</strong>
-    {{/if}}
+if (Reaction.hasOwnerAccess()) {
+  Logger.info("The Reaction account has owner access");
+}
 ```
 
 ## Admin
 
 Users with "admin" role are full-permission, site-wide users.
 
-**To check if user has admin access:**
+**To check if user has admin access in browser code:**
 
 ```js
 // client / server
 import Logger from "@reactioncommerce/logger";
-import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Reaction } from "/client/api";
 
 if (Reaction.hasAdminAccess()) {
-  Logger.info("The Reaction user has Admin Access");
+  Logger.info("The Reaction account has admin access");
 }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasAdminAccess` helper.
-
-```handlebars
-<!-- template -->
-{{#if hasAdminAccess}}
-  <strong>This has admin access</strong>
-{{/if}}
 ```
 
 ## Dashboard
 
 Users with "dashboard" role are limited-permission, site-wide users.
 
-**To check if user has Dashboard access:**
+**To check if user has Dashboard access in browser code:**
 
 ```js
 import Logger from "@reactioncommerce/logger";
-import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Reaction } from "/client/api";
 
 if (Reaction.hasDashboardAccess()) {
-  Logger.info("The Reaction user has Owner Access");
+  Logger.info("The Reaction account has dashboard access");
 }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasDashboardAccess` helper.
-
-```handlebars
-{{#if hasDashboardAccess}}
-  <strong>This has dashboard access</strong>
-{{/if}}
-```
-
-To check if user has some specific permissions:
-
-## hasPermission
-
-Client
-
-```js
-// client
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-// can be a String or Array of strings
-const permissions = ["guest", "profile"];
-
-Reaction.hasPermission(permissions);
-```
-
-Server
-
-Uses the current shop and current user if either is not defined
-
-```js
-// server
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-// can be a String or Array of strings
-const permissions = ["guest", "profile"];
-
-Reaction.hasPermission(permissions, shop, userId);
-```
-
-## hasPermission helper
-
-Helpers in template in templates:
-
-```html
-{{#if hasPermission permissions}}
-  <strong> has permission </strong>
-{{/if}}
-```
-
-`/client/modules/core/helpers/permissions.js` exports the `hasPermission` helper.
-
-## Reaction.Apps()
-
-This core helper method gets all package apps that match the filter passed in. You can use this as in the example below to
-get all enabled packages for payments.
-
-```js
-Reaction.Apps({
-  provides: "paymentMethod",
-  enabled: true
-});
-```
-
-You can also pass in an `audience` field to filter returned apps based on assigned roles for the user.
-[(source)](https://github.com/reactioncommerce/reaction/blob/master/client/modules/core/helpers/apps.js#L106-L127)
-
-```js
-Reaction.Apps({
-  provides: "settings",
-  enabled: true,
-  audience: Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId())
-});
 ```
 
 ## Permission Groups
@@ -202,42 +58,3 @@ Reaction.Apps({
 Permission Groups are are way to grant multiple users a group of permissions. The Accounts Dashboard provides a way to create a group and add users to them.
 Reaction currently ships with the four groups: Guest, Customer, Shop Manager and Owner. The Shop Manager and Owner groups are admin groups.
 Guest group is by default for anonymous (un-registered) users while Customer group is by default for registered users (users who created accounts).
-
-If you installed a package that adds new permissions, you need to run:
-
-```js
-Reaction.addRolesToGroups({
-  allShops: true,
-  groups: ["guest", "group"],
-  roles: ["new-permission"]
-});
-```
-
-This will add the new permissions to the group and update all existing users belonging to that group.
-
-### Updating to 1.5.0
-
-For updating to 1.5.0, note these changes:
-
-1. The previous `shop.defaultVisitorRoles` are the roles now defined in the `guest` group.
-2. The previous `shop.defaultCustomerRoles` are the roles now defined in the default `customer` group.
-3. The default roles set previously on the Shop schema are now present on server export of Reaction, `Reaction.defaultVisitorRoles`.
-
-So, if you had a previous reference to `shop.defaultVisitorRoles`, use the group object, `Groups.find({slug: "guest", shopId}).permissions`.
-
-#### Custom Default Groups
-
-If you need to have more default groups on initializing your app, you can call the `createGroups()` method passing in the shopId and a roles object containining key-value pairs representing the group slug (key) and array of roles for the group (value). See the [documentation page](http://api.docs.reactioncommerce.com/global.html#createGroups) for more details. This can be done, for example, in an `afterCoreInit` function e.g
-
-```js
-const context = Promise.await(getGraphQLContextInMeteorMethod(Reaction.getUserId()));
-
-context.appEvents.on("afterCoreInit", () => {
-  Reaction.createGroups({
-    shopId,
-    roles: {
-      influencers: [...customerRoles, ...influencerRoles]
-    }
-  });
-});
-```

--- a/public-docs/permissions.md
+++ b/public-docs/permissions.md
@@ -33,7 +33,6 @@ Reaction.registerPackage({
   label: "Dashboard",
   name: "reaction-dashboard",
   icon: "fa fa-th",
-  autoEnable: true,
   settings: {
     name: "Dashboard"
   },

--- a/public-docs/plugin-creating-2.md
+++ b/public-docs/plugin-creating-2.md
@@ -2,12 +2,12 @@
 id: plugin-creating-2
 title: Part 1: Creating your plugin
 ---
-    
+
 ## What is a Reaction plugin?
 
 A Reaction plugin is a plain old JavaScript module.
 
-Going forward, Meteor is moving away from their proprietary package format and towards the [ES6 modules](http://exploringjs.com/es6/ch_modules.html) standard. Reaction is adopting the module approach as well. While adding some boilerplate structure, using JavaScript's native built-in modules adds clarity and removes some of the _magic_ that created global Meteor elements. 
+Going forward, Meteor is moving away from their proprietary package format and towards the [ES6 modules](http://exploringjs.com/es6/ch_modules.html) standard. Reaction is adopting the module approach as well. While adding some boilerplate structure, using JavaScript's native built-in modules adds clarity and removes some of the _magic_ that created global Meteor elements.
 
 Before moving forward you should have a good understanding of how [imports](https://developer.mozilla.org/en/docs/web/javascript/reference/statements/import) and
 [exports](https://developer.mozilla.org/en/docs/web/javascript/reference/statements/export) work
@@ -22,14 +22,14 @@ Start with a fresh checkout of the latest version of Reaction.
 1. Create a directory with the name of the plugin, `beesknees`, within the `imports/plugins/custom` directory of Reaction.
 2. Within `beesknees`, create `client` and `server` directories.
 
-You may, at this point want to also `git init` so you can start tracking your new package with source control. 
+You may, at this point want to also `git init` so you can start tracking your new package with source control.
 
 The reference files for this tutorial are available [here](https://github.com/reactioncommerce/reaction-example-plugin).
 
 ### Create a [`register.js`](https://github.com/reactioncommerce/reaction-example-plugin/blob/master/register.js)
 
 The first file we create is going to be our `register.js`. This is absolutely the bare minimum you need to create
-a plugin. The `register.js` adds your plugin to the Registry, the Packages collection in the database. 
+a plugin. The `register.js` adds your plugin to the Registry, the Packages collection in the database.
 
 3. Create a `register.js` file would look something like this:
 
@@ -40,8 +40,7 @@ import Reaction from "/imports/plugins/core/core/server/Reaction";
 Reaction.registerPackage({
   label: "Bees Knees",
   name: "beesknees",
-  icon: "fa fa-vine",
-  autoEnable: true
+  icon: "fa fa-vine"
 });
 ```
 

--- a/public-docs/plugin-layouts-3.md
+++ b/public-docs/plugin-layouts-3.md
@@ -167,7 +167,6 @@ Reaction.registerPackage({
   label: "Bees Knees",
   name: "beesknees",
   icon: "fa fa-vine",
-  autoEnable: true,
   layout: [
     {
       layout: "coreLayoutBeesknees",

--- a/public-docs/plugin-routes-6.md
+++ b/public-docs/plugin-routes-6.md
@@ -2,7 +2,7 @@
 id: plugin-routes-6
 title: Part 5: Routes
 ---
-    
+
 In any web framework, "routes" are one of the core elements of what happens on a website. Certainly rendering content
 when a user hits a particular URL is a majority of what happens in web development.
 
@@ -20,7 +20,7 @@ Knees wants to add the ubiquitous "About" page to their site and wants to show e
 So the first thing we want to do is add the route in the Registry which we do by adding an entry in the `registry` key in
 our `register.js` file.
 
-This entry will look like this (placed after the `autoEnable: true` entry):
+This entry will look like this:
 
 ```js
   registry: [

--- a/public-docs/registry.md
+++ b/public-docs/registry.md
@@ -2,7 +2,7 @@
 id: registry
 title: Registry
 ---
-    
+
 The `Reaction Registry` is used to add settings, routes, and permissions for Reaction packages, both from Core and any custom package you write.
 
 The Registry is the defining file of any Reaction plugin. You can think of the `register.js` file as similar, but not identical to, the `package.json` file you'd use to define an npm package.
@@ -18,11 +18,10 @@ Once registered, plugins are published to the client in the [Packages publicatio
 Here's an example of the most basic `register.js` file.
 
 ```js
-Reaction.registerPackage({  
+Reaction.registerPackage({
   label: "PackageName",
   name: "reaction-example-package",
   icon: "fa fa-package",
-  autoEnable: true,
   settings: {
     name: "Marketplace",
     enabled: true,
@@ -48,7 +47,6 @@ There are four main sections:
 | `name`       | String  | Used to refer to the plugin internally. Must be unique. Namespace your plugin to avoid conflicts, e.g. `yourorg-plugin-name`.                     |
 | `label`      | String  | The label is displayed wherever the client refers to the plugin with a text label.                                                                |
 | `icon`       | String  | The icon is a set of classes that are used to define an icon. The example above refers to a Font Awesome icon.                                    |
-| `autoEnable` | Boolean | The autoEnable flag tells the app whether or not the plugin should be enabled on load, or if it must be turned on after the app has been started. |
 
 ### Settings object
 
@@ -277,7 +275,7 @@ To add and customize Dashboard panels, use these `provides` values.
   - `icon`
   - `name`
   - `description`
-  - `provides`  
+  - `provides`
 
 ### Payment-related: Methods and Settings
 

--- a/public-docs/registry.md
+++ b/public-docs/registry.md
@@ -18,20 +18,21 @@ Once registered, plugins are published to the client in the [Packages publicatio
 Here's an example of the most basic `register.js` file.
 
 ```js
-Reaction.registerPackage({
-  label: "PackageName",
-  name: "reaction-example-package",
-  icon: "fa fa-package",
-  settings: {
-    name: "Marketplace",
-    enabled: true,
-    public: {
-      somePublicSetting: true
-    }
-  },
-  registry: [] // Array of registry objects - optional
-  layout: [] // Array of layout objects - optional
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "PackageName",
+    name: "reaction-example-package",
+    icon: "fa fa-package",
+    settings: {
+      public: {
+        somePublicSetting: true
+      }
+    },
+    registry: [] // Array of registry objects - optional
+    layout: [] // Array of layout objects - optional
+    // other props
+  });
+}
 ```
 
 There are four main sections:

--- a/public-docs/swag-shop-07-graphql-server-plugin.md
+++ b/public-docs/swag-shop-07-graphql-server-plugin.md
@@ -7,23 +7,29 @@ For our Homepage we want to have some dynamic content that can be changed by non
 
 To do this we need to create a new plugin in the `Reaction` project. We are going to call this plugin `featured-products` and you can find the finished code in the `server` folder in the tutorial repository. You need to place this new directory in `imports/plugins/custom` from the root of your Reaction project
 
-What we want to accomplish is to create a new Query (`featuredProductsByShop`). Let's start by creating the `register.js` at the root our new plugin. This registers all the schemas/queries/resolvers/mutations, etc and makes our plugin visible to the rest of the system.
+What we want to accomplish is to create a new Query (`featuredProductsByShop`). Let's start by creating a file named `register.js` at the root our new plugin. This registers all the schemas/queries/resolvers/mutations, etc and makes our plugin visible to the rest of the system.
 
-Let's just add the skeleton of it for now and we will add more to it as we complete them:
+For now, while we are moving server code off Meteor, you'll actually need two `register.js` files. The first is recognized by Meteor loading and should look like this:
 
 ```javascript
 import Reaction from "/imports/plugins/core/core/server/Reaction";
+import register from "./server/no-meteor/register";
 
-
-Reaction.registerPackage({
-  label: "Featured Products",
-  name: "featured-products",
-});
+Reaction.whenAppInstanceReady(register);
 ```
 
-This file also insures that our files get imported.
+The second `register.js` file goes in the `server/no-meteor` folder. Let's just add the skeleton of it for now and we will add more to it as we complete them:
 
-Now the first thing we are going to create is our GraphQL schema files. You need to create a certain directory heirarchy, in this case it's `server/no-meteor`. All of the files we create in this tutorial will be in the `server/no-meteor` directory.
+```javascript
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Featured Products",
+    name: "featured-products"
+  });
+}
+```
+
+Now the first thing we are going to create is our GraphQL schema files. You need to create a certain directory hierarchy, in this case it's `server/no-meteor`. All of the files we create in this tutorial will be in the `server/no-meteor` directory.
 
 In this directory now create a `schemas` directory, and in that directory create a `schema.graphql` file. I find it easier to think of this file as creating the external API and defining the "shape" of it (as the word schema would imply). So the first thing we do is add our Query. This query will take a `shopId` and return a cursor of featured products. So it looks like this:
 
@@ -46,17 +52,17 @@ Now let's edit our `register.js`
 We will add a new `graphQL` key which will contain a `schemas` entry. We'll import our schema file and add it there.
 
 ```javascript
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import schemas from "./server/no-meteor/schemas";
+import schemas from "./schemas";
 
-
-Reaction.registerPackage({
-  label: "Featured Products",
-  name: "featured-products",
-  graphQL: {
-    schemas
-  }
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Featured Products",
+    name: "featured-products",
+    graphQL: {
+      schemas
+    }
+  });
+}
 ```
 
 That's fine but our query doesn't actually "do" anything (often a requirement!). To make it do something we will need to add a resolver and a query. Let's start with the resolver. At the same level as we created `schemas` let's create a `resolvers` directory, add a `Query` directory (the capital letter there is intentional) and in that `Query` directory add a file called `featuredProductsByShop`. The name of the file **needs** to be the same as our query in order for the GraphQL server to find it. While we're creating files let's also create an `index.js` file there that imports the default and exports it back out as a key in an object
@@ -145,27 +151,27 @@ Nothing really special or fancy here except that if you are used to Meteor devel
 
 The only things extra to point out are that we need to `await` on every database action, the query to `Tags` and inserting the `Tag`.
 
-We now have all our pieces in place, we just need to let the system know about them through entries to our `register.js`. So we just need to add new entries for `resolvers` and `queries`. So our updated `register.js` should look somwething like this:
+We now have all our pieces in place, we just need to let the system know about them through entries to our `register.js`. So we just need to add new entries for `resolvers` and `queries`. So our updated `register.js` should look something like this:
 
 ```javascript
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import queries from "./server/no-meteor/queries";
-import resolvers from "./server/no-meteor/resolvers/index";
-import schemas from "./server/no-meteor/schemas";
+import queries from "./queries";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-
-Reaction.registerPackage({
-  label: "Featured Products",
-  name: "featured-products",
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  queries
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Featured Products",
+    name: "featured-products",
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    queries
+  });
+}
 ```
 
-if you visit GraphiQL or GraphQL playground and hit the "schema" tab you should now see your Query available to the client. If you want to execute the schema you will need to get your encoded shopId. Your shopId should be available in the `Shops` collection and to get the encoded version of it you can execute this command from the command line:
+If you visit GraphQL Playground and hit the "schema" tab you should now see your query available to the client. If you want to execute the schema you will need to get your encoded shopId. Your shopId should be available in the `Shops` collection and to get the encoded version of it you can execute this command from the command line:
 
 ```bash
 echo -n reaction/shop:<your_shop_id> | base64

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -175,7 +175,6 @@
     "running-jest-unit-tests": "Running Jest Unit Tests",
     "running-meteor-integration-tests": "Running Meteor Integration Tests",
     "script-template": "Script Template",
-    "search": "Search",
     "security": "Security",
     "seo-metadata": "Metadata",
     "settings-card": "Settings Card",

--- a/website/versioned_docs/version-2.0.0/creating-a-theme.md
+++ b/website/versioned_docs/version-2.0.0/creating-a-theme.md
@@ -31,9 +31,6 @@ Reaction.registerPackage({
   // Icon for toolbars
   icon: "fa fa-bars",
 
-  // Auto-enable plugin, sets enabled: true in database
-  autoEnable: true,
-
   // Settings for plugin
   settings: {},
 

--- a/website/versioned_docs/version-2.0.0/dev-how-do-i.md
+++ b/website/versioned_docs/version-2.0.0/dev-how-do-i.md
@@ -140,8 +140,6 @@ export default function startup(context) {
 Then import and register the startup function in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
 export default async function register(app) {
   await app.registerPlugin({
     label: "Shipping",
@@ -157,7 +155,7 @@ export default async function register(app) {
 
 ## Emit an app event
 
-Emit app events in API code using `appEvents.emit`. There is currently no limit to what event name you can emit, but generally try to follow established patterns for naming.
+Emit app events in API code using `appEvents.emit`. There is currently no limit to what event name you can emit, but generally try to follow established patterns for naming. Learn more about [App Event Hooks](appevent-hooks.md).
 
 ### In New Server Code
 
@@ -228,32 +226,52 @@ await createNotification(rawCollections, { accountId, type: "orderCanceled", url
 
 ## Add MongoDB collections from a plugin
 
-To create any non-core MongoDB collection that a plugin needs, add a reference to the collection instance on `context.collections` in a startup function.
+To create any non-core MongoDB collection that a plugin needs, use the `collections` option in your plugin's `registerPlugin` call:
 
 ```js
-export default function startup(context) {
-  context.collections.MyCustomCollection = context.app.db.collection("MyCustomCollection");
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "My Custom Plugin",
+    name: "my-custom-plugin",
+    collections: {
+      MyCustomCollection: {
+        name: "MyCustomCollection"
+      }
+    }
+    // other props
+  });
 }
 ```
 
-Now `context.collections.MyCustomCollection` will be available in all query and mutation functions. Note that usually MongoDB will not actually create the collection until the first time you insert into it.
+The `collections` object key is where you will access this collection on `context.collection`, and `name` is the collection name in MongoDB. We recommend you make these the same if you can.
 
-If you need to ensure indexes on any fields, the startup function is a good place to do that, too.
+The example above will make `context.collections.MyCustomCollection` available in all query and mutation functions, and all functions that receive `context`, such as startup functions. Note that usually MongoDB will not actually create the collection until the first time you insert into it.
+
+If you need to ensure indexes on any fields in your collection, see the next section.
 
 ## Ensure MongoDB collection indexes from a plugin
 
-Import the `collectionIndex` util function and call it in a startup function registered by your plugin. It handles errors in a standard way and forces the `background: true` option.
+You can add indexes for your MongoDB collection in the same place you define your collection, the `collections` object of your `registerPlugin` call:
 
 ```js
-import collectionIndex from "/imports/utils/collectionIndex";
-
-export default function startup(context) {
-  collectionIndex(collections.Surcharges, { shopId: 1 });
-
-  // You can pass options as the third argument
-  collectionIndex(collections.Custom, { referenceId: 1 }, { unique: true });
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "My Custom Plugin",
+    name: "my-custom-plugin",
+    collections: {
+      MyCustomCollection: {
+        name: "MyCustomCollection",
+        indexes: [
+          [{ referenceId: 1 }, { unique: true }]
+        ]
+      }
+    }
+    // other props
+  });
 }
 ```
+
+Each item in the `indexes` array is an array of arguments that will be passed to the Mongo `createIndex` function. The `background` option is always set to `true` so you need not include that.
 
 ## Loop over async function results
 

--- a/website/versioned_docs/version-2.0.0/dev-how-do-i.md
+++ b/website/versioned_docs/version-2.0.0/dev-how-do-i.md
@@ -141,17 +141,18 @@ Then import and register the startup function in the plugin's `register.js` file
 
 ```js
 import Reaction from "/imports/plugins/core/core/server/Reaction";
-import startup from "./server/no-meteor/startup";
 
-Reaction.registerPackage({
-  label: "Shipping",
-  name: "reaction-shipping",
-  icon: "fa fa-truck",
-  functionsByType: {
-    startup: [startup]
-  }
-  // other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Shipping",
+    name: "reaction-shipping",
+    icon: "fa fa-truck",
+    functionsByType: {
+      startup: [startup]
+    }
+    // other props
+  });
+}
 ```
 
 ## Emit an app event

--- a/website/versioned_docs/version-2.0.0/dev-how-do-i.md
+++ b/website/versioned_docs/version-2.0.0/dev-how-do-i.md
@@ -147,7 +147,6 @@ Reaction.registerPackage({
   label: "Shipping",
   name: "reaction-shipping",
   icon: "fa fa-truck",
-  autoEnable: true,
   functionsByType: {
     startup: [startup]
   }

--- a/website/versioned_docs/version-2.0.0/graphql-create-mutation.md
+++ b/website/versioned_docs/version-2.0.0/graphql-create-mutation.md
@@ -36,15 +36,16 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Step 4: Create the plugin mutation file
@@ -79,16 +80,17 @@ export default {
 };
 ```
 
-If this is the first mutation for the plugin, you'll also need to pass the full `mutations` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first mutation for the plugin, you'll also need to pass the full `mutations` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import mutations from "./server/no-meteor/mutations";
+import mutations from "./mutations";
 
-Reaction.registerPackage({
-  mutations,
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    mutations,
+    // other props
+  });
+}
 ```
 
 Your plugin mutation function is now available in the GraphQL context as `context.mutations.createSomething`.
@@ -168,20 +170,21 @@ export default {
 };
 ```
 
-Then pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+Then pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 Calling your mutation with GraphQL should now work.

--- a/website/versioned_docs/version-2.0.0/graphql-create-query.md
+++ b/website/versioned_docs/version-2.0.0/graphql-create-query.md
@@ -35,15 +35,16 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Step 4: Create the plugin query file
@@ -78,16 +79,17 @@ export default {
 };
 ```
 
-If this is the first query for the plugin, you'll also need to pass the full `queries` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first query for the plugin, you'll also need to pass the full `queries` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import queries from "./server/no-meteor/queries";
+import queries from "./queries";
 
-Reaction.registerPackage({
-  queries,
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    queries,
+    // other props
+  });
+}
 ```
 
 Your plugin query function is now available in the GraphQL context as `context.queries.widgets`.
@@ -160,20 +162,21 @@ export default {
 };
 ```
 
-Then pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+Then pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 Calling your query with GraphQL should now work.

--- a/website/versioned_docs/version-2.0.0/graphql-resolvers-file-structure.md
+++ b/website/versioned_docs/version-2.0.0/graphql-resolvers-file-structure.md
@@ -33,17 +33,18 @@ export default {
 You could save that file as `resolvers.js` in `/server/no-meteor` in the payments plugin, and then import it and register it:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 While that would work and may even be fine for a simple custom plugin, there are some downsides. We want to be able to test each complex resolver function, which is easier if each function is in its own file. Also, plugins typically keep growing, so our single file might become too large to easily understand over time.

--- a/website/versioned_docs/version-2.0.0/how-to-add-address-validation-service.md
+++ b/website/versioned_docs/version-2.0.0/how-to-add-address-validation-service.md
@@ -26,7 +26,6 @@ import addressValidation from "./server/addressValidation.js";
 Reaction.registerPackage({
   label: "Great Validation Service",
   name: "great-validation-service",
-  autoEnable: true,
   addressValidationServices: [
     {
       displayName: "Great Validation",

--- a/website/versioned_docs/version-2.0.0/how-to-add-address-validation-service.md
+++ b/website/versioned_docs/version-2.0.0/how-to-add-address-validation-service.md
@@ -17,27 +17,28 @@ In general, to add an address validation service you must do the following:
 
 ### Register an address validation service
 
-Address validation services are registered by passing an array of them to the `addressValidationServices` property of the `Reaction.registerPackage` options.
+Address validation services are registered by passing an array of them to the `addressValidationServices` property of the `registerPlugin` options.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import addressValidation from "./server/addressValidation.js";
+import addressValidation from "./addressValidation.js";
 
-Reaction.registerPackage({
-  label: "Great Validation Service",
-  name: "great-validation-service",
-  addressValidationServices: [
-    {
-      displayName: "Great Validation",
-      functions: {
-        addressValidation
-      },
-      name: "great",
-      supportedCountryCodes: ["US", "CA", "DE", "IN"]
-    }
-  ]
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Great Validation Service",
+    name: "great-validation-service",
+    addressValidationServices: [
+      {
+        displayName: "Great Validation",
+        functions: {
+          addressValidation
+        },
+        name: "great",
+        supportedCountryCodes: ["US", "CA", "DE", "IN"]
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `addressValidationServices` property is the key to making your plugin

--- a/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
+++ b/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
@@ -19,28 +19,29 @@ In general, to add a tax service you must do the following:
 
 ### Register a tax service
 
-Tax services are registered by passing an array of them to the `taxServices` property of the `Reaction.registerPackage` options.
+Tax services are registered by passing an array of them to the `taxServices` property of the `registerPlugin` options.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import calculateOrderTaxes from "./server/no-meteor/util/calculateOrderTaxes";
-import getTaxCodes from "./server/no-meteor/util/getTaxCodes";
+import calculateOrderTaxes from "./util/calculateOrderTaxes";
+import getTaxCodes from "./util/getTaxCodes";
 
-Reaction.registerPackage({
-  label: "Custom Rates",
-  name: "reaction-taxes-rates",
-  taxServices: [
-    {
-      displayName: "Custom Rates",
-      name: "custom-rates",
-      functions: {
-        calculateOrderTaxes,
-        getTaxCodes
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Custom Rates",
+    name: "reaction-taxes-rates",
+    taxServices: [
+      {
+        displayName: "Custom Rates",
+        name: "custom-rates",
+        functions: {
+          calculateOrderTaxes,
+          getTaxCodes
+        }
       }
-    }
-  ]
-  // ...
-});
+    ]
+    // other props
+  });
+}
 ```
 
 See below for how to create the two functions.

--- a/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
+++ b/website/versioned_docs/version-2.0.0/how-to-add-tax-service.md
@@ -29,7 +29,6 @@ import getTaxCodes from "./server/no-meteor/util/getTaxCodes";
 Reaction.registerPackage({
   label: "Custom Rates",
   name: "reaction-taxes-rates",
-  autoEnable: true,
   taxServices: [
     {
       displayName: "Custom Rates",

--- a/website/versioned_docs/version-2.0.0/how-to-create-a-fulfillment-methods-plugin.md
+++ b/website/versioned_docs/version-2.0.0/how-to-create-a-fulfillment-methods-plugin.md
@@ -72,7 +72,6 @@ import getFulfillmentMethodsWithQuotes from "./server/getFulfillmentMethodsWithQ
 Reaction.registerPackage({
   label: "My Fulfillment Plugin",
   name: "my-fulfillment-plugin",
-  autoEnable: true,
   functionsByType: {
     getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
   },

--- a/website/versioned_docs/version-2.0.0/how-to-create-a-fulfillment-methods-plugin.md
+++ b/website/versioned_docs/version-2.0.0/how-to-create-a-fulfillment-methods-plugin.md
@@ -13,7 +13,7 @@ In general, to add a fulfillment method you must do the following:
 - Create a new plugin
 - Create a `getFulfillmentMethodsWithQuotes` function in your plugin
 - Create a React component for operators to enter and edit fulfillment method details, unless they'll be managed in an external system
-- Register the function and the React components using your plugin's `registerPackage` call
+- Register the function and the React components using your plugin's `registerPlugin` call
 
 Reaction ships with one such plugin, `shipping-rates`, which you can look at for inspiration. You will want to remove that plugin if adding your own, unless you're combining multiple fulfillment method sources
 
@@ -67,16 +67,18 @@ Everything needs to be registered to be seen by Reaction core.
 Pass your function in the `functionsByType` list:
 
 ```js
-import getFulfillmentMethodsWithQuotes from "./server/getFulfillmentMethodsWithQuotes";
+import getFulfillmentMethodsWithQuotes from "./getFulfillmentMethodsWithQuotes";
 
-Reaction.registerPackage({
-  label: "My Fulfillment Plugin",
-  name: "my-fulfillment-plugin",
-  functionsByType: {
-    getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
-  },
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "My Fulfillment Plugin",
+    name: "my-fulfillment-plugin",
+    functionsByType: {
+      getFulfillmentMethodsWithQuotes: [getFulfillmentMethodsWithQuotes]
+    },
+    // other props
+  });
+}
 ```
 
 ### Settings UI
@@ -84,17 +86,19 @@ Reaction.registerPackage({
 If your plugin needs any settings that it will not get from environment variables, register the React component in the `registry` array:
 
 ```js
-Reaction.registerPackage({
-  // ...
-  registry: [
-    {
-      label: "My Fulfillment Plugin",
-      provides: ["shippingSettings"],
-      container: "dashboard",
-      template: "MyFulfillmentPluginSettings"
-    }
-  ]
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    registry: [
+      {
+        label: "My Fulfillment Plugin",
+        provides: ["shippingSettings"],
+        container: "dashboard",
+        template: "MyFulfillmentPluginSettings"
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `label` is shown in the operator UI to group the settings for each fulfillment plugin. The `provides` property must be an array containing `"shippingSettings"`. Set `template` to the name of your React component, which you must register with `registerComponent` in client code.

--- a/website/versioned_docs/version-2.0.0/how-to-create-a-payment-provider.md
+++ b/website/versioned_docs/version-2.0.0/how-to-create-a-payment-provider.md
@@ -182,7 +182,6 @@ Reaction.registerPackage({
   label: "Stripe",
   name: "reaction-stripe",
   icon: "fa fa-cc-stripe",
-  autoEnable: true,
   paymentMethods: [{
     name: "stripe_card",
     displayName: "Stripe Card",

--- a/website/versioned_docs/version-2.0.0/how-to-create-a-payment-provider.md
+++ b/website/versioned_docs/version-2.0.0/how-to-create-a-payment-provider.md
@@ -16,7 +16,7 @@ In general, to add a payment method you must do the following:
 - Add routes for callback URLs if necessary
 - Create a React component for collecting any necessary payment data
 - Create a React component for operators to enter and edit necessary settings for your payment method
-- Register the method definition, its functions, the routes, and the React components using your plugin's `registerPackage` call
+- Register the method definition, its functions, the routes, and the React components using your plugin's `registerPlugin` call
 
 There are two included plugins (in `/imports/plugins/included`) that provide payment methods, which you can look at for inspiration:
 - payments-example
@@ -116,7 +116,7 @@ You are expected to return a valid payment object similar to this:
 Be sure that:
 - the `mode` is "authorize"
 - the `status` is "created"
-- the `name` matches the method name you specified in `registerPackage` and in the GraphQL `PaymentMethodName` enum
+- the `name` matches the method name you specified in `registerPlugin` and in the GraphQL `PaymentMethodName` enum
 - `amount` matches what was passed in
 - All required properties are present
 
@@ -173,28 +173,30 @@ If you followed [How To: Create a new GraphQL mutation](./graphql-create-mutatio
 Here's an example of how to register the payment methods your plugin provides:
 
 ```js
-import stripeCapturePayment from "./server/no-meteor/util/stripeCapturePayment";
-import stripeCreateAuthorizedPayment from "./server/no-meteor/util/stripeCreateAuthorizedPayment";
-import stripeCreateRefund from "./server/no-meteor/util/stripeCreateRefund";
-import stripeListRefunds from "./server/no-meteor/util/stripeListRefunds";
+import stripeCapturePayment from "./util/stripeCapturePayment";
+import stripeCreateAuthorizedPayment from "./util/stripeCreateAuthorizedPayment";
+import stripeCreateRefund from "./util/stripeCreateRefund";
+import stripeListRefunds from "./util/stripeListRefunds";
 
-Reaction.registerPackage({
-  label: "Stripe",
-  name: "reaction-stripe",
-  icon: "fa fa-cc-stripe",
-  paymentMethods: [{
-    name: "stripe_card",
-    displayName: "Stripe Card",
-    canRefund: true,
-    functions: {
-      capturePayment: stripeCapturePayment,
-      createAuthorizedPayment: stripeCreateAuthorizedPayment,
-      createRefund: stripeCreateRefund,
-      listRefunds: stripeListRefunds
-    }
-  }],
-  // ...
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    label: "Stripe",
+    name: "reaction-stripe",
+    icon: "fa fa-cc-stripe",
+    paymentMethods: [{
+      name: "stripe_card",
+      displayName: "Stripe Card",
+      canRefund: true,
+      functions: {
+        capturePayment: stripeCapturePayment,
+        createAuthorizedPayment: stripeCreateAuthorizedPayment,
+        createRefund: stripeCreateRefund,
+        listRefunds: stripeListRefunds
+      }
+    }],
+    // other props
+  });
+}
 ```
 
 Each object in `paymentMethods` must have a `name` and `displayName`.
@@ -210,17 +212,19 @@ The `canRefund` option is `true` by default, but if your method does not support
 If your plugin needs any settings that it will not get from environment variables, register the React component in the `registry` array:
 
 ```js
-Reaction.registerPackage({
-  // ...
-  registry: [
-    {
-      label: "Acme Payments",
-      provides: ["paymentSettings"],
-      container: "dashboard",
-      template: "AcmePaymentsPluginSettings"
-    }
-  ]
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    registry: [
+      {
+        label: "Acme Payments",
+        provides: ["paymentSettings"],
+        container: "dashboard",
+        template: "AcmePaymentsPluginSettings"
+      }
+    ]
+    // other props
+  });
+}
 ```
 
 The `label` is shown in the operator UI to group the settings for each payment plugin. The `provides` property must be an array containing `"paymentSettings"`. Set `template` to the name of your React component, which you must register with `registerComponent` in client code.

--- a/website/versioned_docs/version-2.0.0/how-to-extend-graphql-to-add-field.md
+++ b/website/versioned_docs/version-2.0.0/how-to-extend-graphql-to-add-field.md
@@ -33,15 +33,16 @@ Sometimes you only need to extend GraphQL to add a field to an existing type. He
 1. If not already done, register your schemas in the plugin's `register.js` file:
 
     ```js
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
-    import schemas from "./server/no-meteor/schemas";
+    import schemas from "./schemas";
 
-    Reaction.registerPackage({
-      graphQL: {
-        schemas
-      },
-      // ...other props
-    });
+    export default async function register(app) {
+      await app.registerPlugin({
+        graphQL: {
+          schemas
+        },
+        // other props
+      });
+    }
     ```
 
 ## Create a field resolver if necessary
@@ -77,20 +78,21 @@ export default {
 };
 ```
 
-If this is the first resolver for the plugin, pass the full `resolvers` object to `registerPackage` in the plugin's `register.js` file:
+If this is the first resolver for the plugin, pass the full `resolvers` object to `registerPlugin` in the plugin's `register.js` file:
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import resolvers from "./server/no-meteor/resolvers";
-import schemas from "./server/no-meteor/schemas";
+import resolvers from "./resolvers";
+import schemas from "./schemas";
 
-Reaction.registerPackage({
-  graphQL: {
-    resolvers,
-    schemas
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    graphQL: {
+      resolvers,
+      schemas
+    },
+    // other props
+  });
+}
 ```
 
 You should now be able to query for your custom field using GraphQL.

--- a/website/versioned_docs/version-2.0.0/how-to-extend-product.md
+++ b/website/versioned_docs/version-2.0.0/how-to-extend-product.md
@@ -70,18 +70,18 @@ Refer to [How To: Extend GraphQL to add a field](./how-to-extend-graphql-to-add-
 
 *Skip this step if your property is not needed in the published catalog*
 
-A plugin can include a `catalog` object in `registerPackage`, with `customPublishedProductFields` and `customPublishedProductVariantFields` that are set to arrays of property names. These will be appended to the core list of fields for which published status should be tracked. This is used to build the hashes that are used to display an indicator when changes need to be published.
+A plugin can include a `catalog` object in `registerPlugin`, with `customPublishedProductFields` and `customPublishedProductVariantFields` that are set to arrays of property names. These will be appended to the core list of fields for which published status should be tracked. This is used to build the hashes that are used to display an indicator when changes need to be published.
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-Reaction.registerPackage({
-  catalog: {
-    customPublishedProductFields: ["myProperty"],
-    customPublishedProductVariantFields: ["myProperty"]
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    catalog: {
+      customPublishedProductFields: ["myProperty"],
+      customPublishedProductVariantFields: ["myProperty"]
+    },
+    // other props
+  });
+}
 ```
 
 ### Register a function that publishes custom property
@@ -89,15 +89,16 @@ Reaction.registerPackage({
 *Skip this step if your property is not needed in the published catalog*
 
 ```js
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-import publishProductToCatalog from "./server/no-meteor/publishProductToCatalog";
+import publishProductToCatalog from "./publishProductToCatalog";
 
-Reaction.registerPackage({
-  functionsByType: {
-    publishProductToCatalog: [publishProductToCatalog]
-  },
-  // ...other props
-});
+export default async function register(app) {
+  await app.registerPlugin({
+    functionsByType: {
+      publishProductToCatalog: [publishProductToCatalog]
+    },
+    // other props
+  });
+}
 ```
 
 Where the `publishProductToCatalog` function looks something like this:

--- a/website/versioned_docs/version-2.0.0/how-to-store-custom-order-fields.md
+++ b/website/versioned_docs/version-2.0.0/how-to-store-custom-order-fields.md
@@ -49,7 +49,7 @@ const order = {
 ```
 
 ## Transforming or Adding Custom Order Fields on the Server
-Whether or not you've allowed clients to send additional order data, you can also provide a function that returns custom order fields on the server. Do this using the `functionsByType` option in `registerPackage`:
+Whether or not you've allowed clients to send additional order data, you can also provide a function that returns custom order fields on the server. Do this using the `functionsByType` option in `registerPlugin`:
 
 ```js
 functionsByType: {

--- a/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
+++ b/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
@@ -26,7 +26,9 @@ The Reaction Platform is the easiest way to run the entire suite of Reaction ser
 
 > **Linux**: Docker Compose is included when installing Docker on Mac and Windows, but will need to be installed separately on Linux.
 
-2. Before you get started, make sure you are not running any applications on the default ports: `3000`, `4000`, `4444`, `4445`, `5555`, `5432`, and `27017`.
+2. Before you get started:
+  - Increase the memory and CPU allocated to Docker in the Docker settings. We recommend at least 4 GiB memory. The default values are usually not sufficient to run the full Reaction system. See the [troubleshooting-development](./troubleshooting-development#memory-errors-or-errors-about-meteor-rawlogs) article for more information.
+  - Make sure you are not running any applications on the default ports: `3000`, `4000`, `4444`, `4445`, `5555`, `5432`, and `27017`.
 
 3. Clone [**Reaction Platform**](https://github.com/reactioncommerce/reaction-platform)
 

--- a/website/versioned_docs/version-2.0.0/permissions.md
+++ b/website/versioned_docs/version-2.0.0/permissions.md
@@ -34,7 +34,6 @@ Reaction.registerPackage({
   label: "Dashboard",
   name: "reaction-dashboard",
   icon: "fa fa-th",
-  autoEnable: true,
   settings: {
     name: "Dashboard"
   },

--- a/website/versioned_docs/version-2.0.0/permissions.md
+++ b/website/versioned_docs/version-2.0.0/permissions.md
@@ -4,59 +4,7 @@ title: Permissions
 original_id: permissions
 ---
 
-[alanning:roles](https://github.com/alanning/meteor-roles) package provides Reaction permissions support.
-
-## Packages
-
-### Permissions are grouped by `shopId`
-
-Package specific roles can be defined in `register.js`, by adding custom permissions to registry entries with:
-
-```js
-  permissions: [
-    {
-      label: "Custom Permission"
-      permission: "custom/permission"
-    }
-  ]
-```
-
-Permission of the current route and user are compared against the package route by default, adding specific permissions to the registry entry is optional.
-
-For using shop permissions in some packages you must add it into register directive. If we add this package then permissions will be available in Shop Accounts Settings.
-
-Another example:
-
-```js
-import { Reaction } from "/server/api";
-
-Reaction.registerPackage({
-  label: "Dashboard",
-  name: "reaction-dashboard",
-  icon: "fa fa-th",
-  settings: {
-    name: "Dashboard"
-  },
-  registry: [{
-    provides: "dashboard",
-    workflow: "coreDashboardWorkflow",
-    template: "dashboardPackages",
-    name: "dashboardPackages",
-    label: "Core",
-    description: "Reaction core shop configuration",
-    icon: "fa fa-th",
-    priority: 0,
-    container: "core",
-    permissions: [{
-      label: "Dashboard",
-      permission: "dashboard"
-    }]
-   });
-```
-
-At the point where Packages are published in the app, each registry item permissions are collected and put on the
-package registry [(source)](https://github.com/reactioncommerce/reaction/blob/master/server/publications/collections/packages.js#L31-L56).
-Based on these permissions, we can enable or disable functionality depending on user roles.
+The [alanning:roles](https://github.com/alanning/meteor-roles) Meteor package provides Reaction permissions support.
 
 ## Owner
 
@@ -64,138 +12,46 @@ The initial setup user was added to the shops 'owner' permission group with the 
 
 Users with "owner" role are full-permission, app-wide users.
 
-**To check if user has owner access:**
+**To check if user has owner access in browser code:**
 
 ```js
-    # client / server
-    import Logger from "@reactioncommerce/logger";
-    import Reaction from "/imports/plugins/core/core/server/Reaction";
+import Logger from "@reactioncommerce/logger";
+import { Reaction } from "/client/api";
 
-    if ( Reaction.hasOwnerAccess() ) {
-      Logger.info("The Reaction user has Owner Access");
-    }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasOwnerAccess` helper.
-
-```html
-    # template
-    {{#if hasOwnerAccess}}
-      <strong>This has owner access</strong>
-    {{/if}}
+if (Reaction.hasOwnerAccess()) {
+  Logger.info("The Reaction account has owner access");
+}
 ```
 
 ## Admin
 
 Users with "admin" role are full-permission, site-wide users.
 
-**To check if user has admin access:**
+**To check if user has admin access in browser code:**
 
 ```js
 // client / server
 import Logger from "@reactioncommerce/logger";
-import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Reaction } from "/client/api";
 
 if (Reaction.hasAdminAccess()) {
-  Logger.info("The Reaction user has Admin Access");
+  Logger.info("The Reaction account has admin access");
 }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasAdminAccess` helper.
-
-```handlebars
-<!-- template -->
-{{#if hasAdminAccess}}
-  <strong>This has admin access</strong>
-{{/if}}
 ```
 
 ## Dashboard
 
 Users with "dashboard" role are limited-permission, site-wide users.
 
-**To check if user has Dashboard access:**
+**To check if user has Dashboard access in browser code:**
 
 ```js
 import Logger from "@reactioncommerce/logger";
-import Reaction from "/imports/plugins/core/core/server/Reaction";
+import { Reaction } from "/client/api";
 
 if (Reaction.hasDashboardAccess()) {
-  Logger.info("The Reaction user has Owner Access");
+  Logger.info("The Reaction account has dashboard access");
 }
-```
-
-`/client/modules/core/helpers/templates.js` exports the `hasDashboardAccess` helper.
-
-```handlebars
-{{#if hasDashboardAccess}}
-  <strong>This has dashboard access</strong>
-{{/if}}
-```
-
-To check if user has some specific permissions:
-
-## hasPermission
-
-Client
-
-```js
-// client
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-// can be a String or Array of strings
-const permissions = ["guest", "profile"];
-
-Reaction.hasPermission(permissions);
-```
-
-Server
-
-Uses the current shop and current user if either is not defined
-
-```js
-// server
-import Reaction from "/imports/plugins/core/core/server/Reaction";
-
-// can be a String or Array of strings
-const permissions = ["guest", "profile"];
-
-Reaction.hasPermission(permissions, shop, userId);
-```
-
-## hasPermission helper
-
-Helpers in template in templates:
-
-```html
-{{#if hasPermission permissions}}
-  <strong> has permission </strong>
-{{/if}}
-```
-
-`/client/modules/core/helpers/permissions.js` exports the `hasPermission` helper.
-
-## Reaction.Apps()
-
-This core helper method gets all package apps that match the filter passed in. You can use this as in the example below to
-get all enabled packages for payments.
-
-```js
-Reaction.Apps({
-  provides: "paymentMethod",
-  enabled: true
-});
-```
-
-You can also pass in an `audience` field to filter returned apps based on assigned roles for the user.
-[(source)](https://github.com/reactioncommerce/reaction/blob/master/client/modules/core/helpers/apps.js#L106-L127)
-
-```js
-Reaction.Apps({
-  provides: "settings",
-  enabled: true,
-  audience: Roles.getRolesForUser(Reaction.getUserId(), Reaction.getShopId())
-});
 ```
 
 ## Permission Groups
@@ -203,40 +59,3 @@ Reaction.Apps({
 Permission Groups are are way to grant multiple users a group of permissions. The Accounts Dashboard provides a way to create a group and add users to them.
 Reaction currently ships with the four groups: Guest, Customer, Shop Manager and Owner. The Shop Manager and Owner groups are admin groups.
 Guest group is by default for anonymous (un-registered) users while Customer group is by default for registered users (users who created accounts).
-
-If you installed a package that adds new permissions, you need to run:
-
-```js
-Reaction.addRolesToGroups({
-  allShops: true,
-  groups: ["guest", "group"],
-  roles: ["new-permission"]
-});
-```
-
-This will add the new permissions to the group and update all existing users belonging to that group.
-
-### Updating to 1.5.0
-
-For updating to 1.5.0, note these changes:
-
-1. The previous `shop.defaultVisitorRoles` are the roles now defined in the `guest` group.
-2. The previous `shop.defaultCustomerRoles` are the roles now defined in the default `customer` group.
-3. The default roles set previously on the Shop schema are now present on server export of Reaction, `Reaction.defaultVisitorRoles`.
-
-So, if you had a previous reference to `shop.defaultVisitorRoles`, use the group object, `Groups.find({slug: "guest", shopId}).permissions`.
-
-#### Custom Default Groups
-
-If you need to have more default groups on initializing your app, you can call the `createGroups()` method passing in the shopId and a roles object containining key-value pairs representing the group slug (key) and array of roles for the group (value). See the [documentation page](http://api.docs.reactioncommerce.com/global.html#createGroups) for more details. This can be done, for example, in an afterCoreInit function e.g
-
-```js
-Hooks.Events.add("afterCoreInit", () => {
-  Reaction.createGroups({
-    shopId,
-    roles: {
-      influencers: [...customerRoles, ...influencerRoles]
-    }
-  });
-});
-```

--- a/website/versioned_docs/version-2.0.0/plugin-layouts-3.md
+++ b/website/versioned_docs/version-2.0.0/plugin-layouts-3.md
@@ -168,7 +168,6 @@ Reaction.registerPackage({
   label: "Bees Knees",
   name: "beesknees",
   icon: "fa fa-vine",
-  autoEnable: true,
   layout: [
     {
       layout: "coreLayoutBeesknees",


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

Docs updates for some recent 2.0 changes.

- most of this is changing `Reaction.registerPackage` examples to the new non-Meteor `registerPlugin`.
- changes the docs about how to add Mongo collections from a plugin
- remove some outdated info about permissions
- remove `autoEnable: true` from examples since all plugins are auto-enabled now
- mention Docker memory requirements in the setup docs
- explain more about why GraphQL IDs are the way they are