### PR TITLE
Add Upgrade to 2.0 Instructions

### DIFF
--- a/public-docs/installation-reaction-platform.md
+++ b/public-docs/installation-reaction-platform.md
@@ -131,7 +131,7 @@ git pull origin master
 docker-compose run --rm web yarn install
 ```
 
-4. You are nwo ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
+4. You are now ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
 
 ```sh
 cd reaction-platform

--- a/public-docs/installation-reaction-platform.md
+++ b/public-docs/installation-reaction-platform.md
@@ -104,6 +104,50 @@ docker-compose logs -f
 
 7. Congrats 🎉  Now you're running the entire suite of Reaction Platform services and ready to start developing.
 
+## Upgrading from 1.x?
+
+If you are upgrading from Reaction 1.x, follow these steps:
+
+1. Pull locally the latest changes from the [reaction-platform repository](https://github.com/reactioncommerce/reaction-platform)
+
+```sh
+cd reaction-platform
+git pull origin master
+```
+
+2. Pull locally the latest changes from the [reaction repository](https://github.com/reactioncommerce/reaction) and update packages
+
+```sh
+cd reaction-platform/reaction
+git pull origin master
+docker-compose run --rm reaction npm install
+```
+
+3. Pull locally the latest changes from the [example-storefront repository](https://github.com/reactioncommerce/example-storefront) and update packages
+
+```sh
+cd reaction-platform/example-storefront
+git pull origin master
+docker-compose run --rm web yarn install
+```
+
+4. You are nwo ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
+
+```sh
+cd reaction-platform
+make
+```
+
+> **Note:** As of Reaction 2.0 the CLI is deprecated and unsupported. You can use Docker commands instead. See the [Reaction CLI](./reaction-cli) article for more information.
+
+## Upgrading from an older 2.0 release candidate?
+
+If you are upgrading from an older 2.0 release candidate, follow the steps listed in the [Installation](#installation) section of this doc. 
+
+## Repository Branches
+
+With Reaction 2.0 release, we introduced a `develop` branch at both the [Reaction](https://github.com/reactioncommerce/reaction) and the [example-storefront](https://github.com/reactioncommerce/example-storefront) repositories. This branch contains all the latest changes, while `master` is our stable branch.
+
 ## Developing with Reaction Platform
 
 Once you've bootstrapped the entire Reaction development in Docker, use `make start` to start all containers.

--- a/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
+++ b/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
@@ -137,7 +137,7 @@ git pull origin master
 docker-compose run --rm web yarn install
 ```
 
-4. You are nwo ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
+4. You are now ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
 
 ```sh
 cd reaction-platform

--- a/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
+++ b/website/versioned_docs/version-2.0.0/installation-reaction-platform.md
@@ -110,6 +110,49 @@ docker-compose logs -f
 
 **Note:** To login into the Operator UI use the credentials found in the [env.example](https://github.com/reactioncommerce/reaction/blob/master/.env.example#L11-L12) file.
 
+## Upgrading from 1.x?
+
+If you are upgrading from Reaction 1.x, follow these steps:
+
+1. Pull locally the latest changes from the [reaction-platform repository](https://github.com/reactioncommerce/reaction-platform)
+
+```sh
+cd reaction-platform
+git pull origin master
+```
+
+2. Pull locally the latest changes from the [reaction repository](https://github.com/reactioncommerce/reaction) and update packages
+
+```sh
+cd reaction-platform/reaction
+git pull origin master
+docker-compose run --rm reaction npm install
+```
+
+3. Pull locally the latest changes from the [example-storefront repository](https://github.com/reactioncommerce/example-storefront) and update packages
+
+```sh
+cd reaction-platform/example-storefront
+git pull origin master
+docker-compose run --rm web yarn install
+```
+
+4. You are nwo ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
+
+```sh
+cd reaction-platform
+make
+```
+
+> **Note:** As of Reaction 2.0 the CLI is deprecated and unsupported. You can use Docker commands instead. See the [Reaction CLI](./reaction-cli) article for more information.
+
+## Upgrading from an older 2.0 release candidate?
+
+If you are upgrading from an older 2.0 release candidate, follow the steps listed in the [Installation](#installation) section of this doc. 
+
+## Repository Branches
+
+With Reaction 2.0 release, we introduced a `develop` branch at both the [Reaction](https://github.com/reactioncommerce/reaction) and the [example-storefront](https://github.com/reactioncommerce/example-storefront) repositories. This branch contains all the latest changes, while `master` is our stable branch.
 
 ## Developing with Reaction Platform
 


### PR DESCRIPTION
Resolves #838 
Impact: **major**  
Type: **docs**

## Issue
These docs:
- [Install with Reaction Platform](https://docs.reactioncommerce.com/docs/next/installation-reaction-platform)
- [Install with Reaction Platform](https://docs.reactioncommerce.com/docs/installation-reaction-platform)

need instructions on how to upgrade a) from 1.x, or b) from an older 2.0 release candidate

Also we must add a section on develop vs master branches and a warning that reaction CLI has been deprecated.

## Solution & Screenshots
![image](https://user-images.githubusercontent.com/11715799/60807269-e242cc80-a18d-11e9-8aa3-ddac5977d8ff.png)

![image](https://user-images.githubusercontent.com/11715799/60807293-f38bd900-a18d-11e9-9bf7-3773d2e7f058.png)


## Breaking changes
None.

## Testing
Check the following paragraphs:
- http://localhost:4242/docs/installation-reaction-platform#upgrading-from-1x
- http://localhost:4242/docs/installation-reaction-platform#upgrading-from-an-older-20-release-candidate
- http://localhost:4242/docs/installation-reaction-platform#repository-branches
- http://localhost:4242/docs/next/installation-reaction-platform#upgrading-from-1x
- http://localhost:4242/docs/next/installation-reaction-platform#upgrading-from-an-older-20-release-candidate
- http://localhost:4242/docs/next/installation-reaction-platform#repository-branches