### PR TITLE
Remove Meteor component topics from sidebars for v2.0.0 and 'next' as indicated

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -155,32 +155,7 @@
       "template-helpers"
     ],
     "For Developers: Meteor App Client Components": [
-      "blocks-api",
-      "components",
-      "components-api",
-      "components-primary-app-bar",
-      "alerts",
-      "badge",
-      "cards",
-      "clickToCopy",
-      "divider",
-      "dropDownMenu",
-      "icon",
-      "link",
-      "lists",
-      "media",
-      "menu",
-      "metadata",
-      "multi-select",
-      "popover",
-      "avatar",
-      "settings-card",
-      "slider",
-      "sortableTable",
-      "switch",
-      "tags",
-      "tooltip",
-      "translation"
+      "blocks-api"
     ],
     "Testing": [
       "testing-reaction",

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -155,32 +155,7 @@
       "version-2.0.0-template-helpers"
     ],
     "For Developers: Meteor App Client Components": [
-      "version-2.0.0-blocks-api",
-      "version-2.0.0-components",
-      "version-2.0.0-components-api",
-      "version-2.0.0-components-primary-app-bar",
-      "version-2.0.0-alerts",
-      "version-2.0.0-badge",
-      "version-2.0.0-cards",
-      "version-2.0.0-clickToCopy",
-      "version-2.0.0-divider",
-      "version-2.0.0-dropDownMenu",
-      "version-2.0.0-icon",
-      "version-2.0.0-link",
-      "version-2.0.0-lists",
-      "version-2.0.0-media",
-      "version-2.0.0-menu",
-      "version-2.0.0-metadata",
-      "version-2.0.0-multi-select",
-      "version-2.0.0-popover",
-      "version-2.0.0-avatar",
-      "version-2.0.0-settings-card",
-      "version-2.0.0-slider",
-      "version-2.0.0-sortableTable",
-      "version-2.0.0-switch",
-      "version-2.0.0-tags",
-      "version-2.0.0-tooltip",
-      "version-2.0.0-translation"
+      "version-2.0.0-blocks-api"
     ],
     "Testing": [
       "version-2.0.0-testing-reaction",


### PR DESCRIPTION


Signed-off-by: Christopher Shepherd <christopher@reactioncommerce.com>

Resolves #847 
Impact: **minor**  
Type: **docs**

## Issue

Removes sidebar links to deprecated Meteor components; Also removes v2.0.0 versioned documentation for PrimaryAppBar (ie versioned_docs/version-2.0.0/components-primary-app-bar.md)