### PR TITLE
(docs) update how to get reaction version

### DIFF
--- a/public-docs/reaction-cli.md
+++ b/public-docs/reaction-cli.md
@@ -9,13 +9,11 @@ This document lists some handy commands to use while developing on Reaction.
 
 ## Check Version
 
-Use `grep version package.json` to check what version of Reaction you are currently running.
+Use `npm run version --silent` from your reaction directory, to check what version of Reaction you are currently running.
 
 ```sh
-grep version package.json
-
-"version": "2.0.0-rc.10",
-          "last 2 versions"
+> npm run version --silent
+2.0.0-rc.10
 ```
 
 ## Run Tests

--- a/website/versioned_docs/version-2.0.0/reaction-cli.md
+++ b/website/versioned_docs/version-2.0.0/reaction-cli.md
@@ -10,11 +10,12 @@ This document lists some handy commands to use while developing on Reaction.
 
 ## Check Version
 
-Use `npm run version --silent` from your reaction directory, to check what version of Reaction you are currently running.
+Use `grep version package.json` to check what version of Reaction you are currently running.
 
 ```sh
-> npm run version --silent
-2.0.0-rc.10
+> grep version package.json
+"version": "2.0.0-rc.10",
+          "last 2 versions"
 ```
 
 ## Run Tests

--- a/website/versioned_docs/version-2.0.0/reaction-cli.md
+++ b/website/versioned_docs/version-2.0.0/reaction-cli.md
@@ -10,13 +10,11 @@ This document lists some handy commands to use while developing on Reaction.
 
 ## Check Version
 
-Use `grep version package.json` to check what version of Reaction you are currently running.
+Use `npm run version --silent` from your reaction directory, to check what version of Reaction you are currently running.
 
 ```sh
-grep version package.json
-
-"version": "2.0.0-rc.10",
-          "last 2 versions"
+> npm run version --silent
+2.0.0-rc.10
 ```
 
 ## Run Tests


### PR DESCRIPTION
Resolves -
Impact: **minor**  
Type: **docs**

## Issue
The output of `grep version package.json` is:
```
"version": "2.0.0",
          "last 2 versions"
```
which is not very clean. We want something cleaner.

## Solution & Screenshots
I added a `version` script at [package.json of reaction repo](https://github.com/reactioncommerce/reaction/blob/develop/package.json#L222) that echoes the value of `$npm_package_version`. 
Run it with: `npm run version --silent`.
The output is `2.0.0-rc.10`.

![image](https://user-images.githubusercontent.com/11715799/61274915-6e1fae80-a7b5-11e9-9c16-4728d2f9910e.png)

This PR is updating the docs to use the same script.

## Breaking changes
Right now the script exists only in `develop`, not in `master`, so maybe we should hold off merging this PR?

## Testing
1. Go to [Reaction CLI](https://docs.reactioncommerce.com/docs/reaction-cli#check-version) and verify that the script displayed is `npm run version --silent`.
2. Run `npm run version --silent` on master and make sure it works.