### PR TITLE
New sharing code article and some fixes

### DIFF
--- a/public-docs/graphql-create-query.md
+++ b/public-docs/graphql-create-query.md
@@ -11,7 +11,14 @@ The complete Reaction Commerce GraphQL API is created by stitching together doma
 
 See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-developing.md#resolver-mutations-and-queries-vs-plugin-mutations-and-queries)
 
-## Step 3: Define the query in the schema
+## Step 3: Name the query
+
+When choosing a name for the query, there are a few rules to follow:
+- In keeping with general GraphQL best practices, do not use verbs such as "list", "get", or "find" at the beginning of your query name. For example, use "cart" instead of "getCart" and "carts" instead of "listCarts".
+- Prefix with adjectives as necessary to fully describe what the query returns. For example, "anonymousCart" and "accountCart" queries.
+- If there are similar queries that take slightly different parameters, add a suffix to clarify. In most cases, we begin the suffix with "By". For example, "accountCartById" and "accountCartByAccountId".
+
+## Step 4: Define the query in the schema
 
 1. If it doesn't already exist, create `/server/no-meteor/schemas` folder in the plugin, and add an `index.js` file there.
 1. If it doesn't already exist, create `schema.graphql` in `/server/no-meteor/schemas` in the plugin.
@@ -46,7 +53,7 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
     }
     ```
 
-## Step 4: Create the plugin query file
+## Step 5: Create the plugin query file
 
 1. If it doesn't already exist, create `/server/no-meteor/queries` folder in the plugin, and add an `index.js` file there.
 2. In `/server/no-meteor/queries`, create a file for the query, e.g. `widgets.js` for the `widgets` query. The file should look something like this:
@@ -66,7 +73,7 @@ export default async function widgets(context) {
 }
 ```
 
-## Step 5: Add the plugin query to the queries context
+## Step 6: Add the plugin query to the queries context
 
 In `/server/no-meteor/queries/index.js` in the plugin, import your query and add it to the default export object. Example:
 
@@ -95,7 +102,7 @@ Your plugin query function is now available in the GraphQL context as `context.q
 
 > NOTE: The queries objects from all plugins are merged, so be sure that another plugin does not have a query with the same name. The last one registered with that name will win, and plugins are generally registered in alphabetical order by plugin name. Tip: You can use this to your advantage if you want to override the query function of a core plugin without modifying core code.
 
-## Step 6: Add a test file for your query
+## Step 7: Add a test file for your query
 
 If your query is in a file named `widgets.js`, your Jest tests should be in a file named `widgets.test.js` in the same folder. Initially you can copy and paste the following test:
 
@@ -111,7 +118,7 @@ test("expect to return a Promise that resolves to null", async () => {
 
 This of course should be updated with tests that are appropriate for whatever your query does.
 
-## Step 7: Create the GraphQL query resolver file
+## Step 8: Create the GraphQL query resolver file
 
 1. If it doesn't already exist, create `/server/no-meteor/resolvers` folder in the plugin, and add an `index.js` file there.
 2. If it doesn't already exist, create `/server/no-meteor/resolvers/Query` folder in the plugin, and add an `index.js` file there. "Query" must be capitalized.
@@ -139,7 +146,7 @@ Make adjustments to the resolver function so that it reads and passes along the 
 - Call `context.queries.<queryName>` (your new plugin query) with the necessary arguments, and `await` a response.
 - Return a single document or an array of them using either `getPaginatedResponse` or `xformArrayToConnection` util function.
 
-## Step 8: Register the resolver
+## Step 9: Register the resolver
 
 In `/server/no-meteor/resolvers/Query/index.js` in the plugin, import your query resolver and add it to the default export object. Example:
 
@@ -192,7 +199,7 @@ export default async function register(app) {
 
 Calling your query with GraphQL should now work.
 
-## Step 9: Add a test file for your query resolver
+## Step 10: Add a test file for your query resolver
 
 If your query resolver is in a file named `widgets.js`, your Jest tests should be in a file named `widgets.test.js` in the same folder. Initially you can copy and paste the following test:
 
@@ -215,12 +222,12 @@ test("calls queries.widgets and returns the result", async () => {
 
 This of course should be updated with tests that are appropriate for whatever your query resolver does. For example, verify that all ID and schema transformations happen.
 
-## Step 10: Finish implementing your query
+## Step 11: Finish implementing your query
 
 Adjust the query function and the query resolver function until they work as expected, with tests that prove it. This will likely involve adding additional arguments, ID transformations, permission checks, and MongoDB queries.
 
 Refer to [Developing the GraphQL API](./graphql-developing) for answers to any questions you might have while implementing your mutation.
 
-## Step 11: Update the JSDoc comments
+## Step 12: Update the JSDoc comments
 
 Write/update jsdoc comments for the plugin query function, the query resolver, and any util functions. The resolver function must have `@memberof <PluginName>/GraphQL` in the jsdoc, and the `@name` must be the full GraphQL schema path in quotation marks, e.g., "Query.widgets". (The quotation marks are necessary for the output API documentation to be correct due to the periods.)

--- a/public-docs/graphql-developing.md
+++ b/public-docs/graphql-developing.md
@@ -37,7 +37,7 @@ The path a GraphQL query or mutation takes is first to a resolver function, whic
 The resolver function:
 - Lives in `server/no-meteor/resolvers` in a plugin folder
 - Returns a Promise (is async)
-- Transforms IDs (see “IDs in GraphQL”) and data structures (where they don’t match internal data structures)
+- Transforms IDs (see [IDs in GraphQL](#ids-in-graphql)) and data structures (where they don’t match internal data structures)
 - May pull things from the GraphQL context to pass to the plugin function
 - May throw a `ReactionError` if anything goes wrong
 - Includes `clientMutationId` in the response (for mutations only)

--- a/public-docs/how-to-share-code-between-plugins.md
+++ b/public-docs/how-to-share-code-between-plugins.md
@@ -1,0 +1,97 @@
+---
+id: how-to-share-code-between-plugins
+title: How To: Share Code Between API Plugins
+---
+
+Sometimes you need one API plugin to provide a function to be called by another plugin. There are several different ways to choose from.
+
+| Method                | Pros                                                                                                                                               | Cons                                                                                                                                                                         |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| functionsByType       | - Easy<br>- Supports multiple functions                                                                                                               | - No way to know which plugin registered a function<br>- No way to label a function or provide additional metadata about it<br>- No way to run the functions in a particular order |
+| queries/mutations     | - Easy                                                                                                                                             | - Does not support multiple functions<br>- No way to label a function or provide additional metadata about it<br>- No way to run the functions in a particular order               |
+| registerPluginHandler | - Full control<br>- Can provide dependency/sorting information<br>- Can provide additional metadata<br>- Can track which plugin registered a function | - A bit more work is required to write the handler                                                                                                                           |
+
+In new code, using `registerPluginHandler` is best.
+
+## functionsByType
+
+One simple way to provide a function to another plugin for a specific purpose is to pass it to `registerPlugin` in the `functionsByType` list.
+
+```js
+import funkyFn from "./funkyFn";
+
+await app.registerPlugin({
+  label: "Cart",
+  name: "reaction-cart",
+  functionsByType: {
+    funky: [funkyFn]
+  }
+});
+```
+
+In another plugin, I can then loop through and call all "funky" functions that were registered by other plugins:
+
+```js
+for (const funkyFn of context.getFunctionsOfType("funky")) {
+  // eslint-disable-next-line no-await-in-loop
+  await funkyFn(...args);
+}
+```
+
+Note that the plugin that calls the functions must document what arguments it will provide and what return value and/or side effects it expects.
+
+## queries / mutations
+
+If you only ever want a single function registered, you might choose to use `context.queries` or `context.mutations` instead of `functionsByType`. The idea here is that your plugin can simply document that it expects to find a function named "expireCarts" (for example) on `context.mutations`, and then call `context.mutations.expireCarts`. Just as with `functionsByType`, the plugin that calls the function must document what arguments it will provide and what return value and/or side effects it expects.
+
+> If more than one plugin registers a query or mutation function, the last one registered will win. There is no error or warning thrown. Being able to override these functions in a custom plugin is a feature of Reaction.
+
+> If your query or mutation function is intended to be called only by other plugins, you do not need to add it to your GraphQL schema or create a GraphQL resolver for it.
+
+## registerPluginHandler
+
+The most flexible way to share code, or really any information, between plugins is by creating a `registerPluginHandler` function. This type of function is registered using `functionsByType`:
+
+```js
+import { registerPluginHandler } from "./registration";
+
+await app.registerPlugin({
+  label: "Cart",
+  name: "reaction-cart",
+  functionsByType: {
+    registerPluginHandler: [registerPluginHandler]
+  }
+});
+```
+
+A `registerPluginHandler` function is called multiple times immediately after all plugins are loaded as the app is starting. It is passed the `registerPlugin` options provided by each plugin. The handler is expected to examine the options and save off anything it needs. This means that any plugin can extend the `registerPlugin` options by documenting something it expects to find there.
+
+The typical and recommended pattern is to have a file named `registration.js` in your plugin, in which you not only define and export your `registerPluginHandler`, but also define and export the related data that other files in your plugin need. For example, here is the `reaction-catalog` plugin's `registration.js` file:
+
+```js
+export const customPublishedProductFields = [];
+export const customPublishedProductVariantFields = [];
+
+/**
+ * @summary Will be called for every plugin
+ * @param {Object} options The options object that the plugin passed to registerPlugin
+ * @returns {undefined}
+ */
+export function registerPluginHandler({ catalog }) {
+  if (catalog) {
+    const { publishedProductFields, publishedProductVariantFields } = catalog;
+    if (Array.isArray(publishedProductFields)) {
+      customPublishedProductFields.push(...publishedProductFields);
+    }
+    if (Array.isArray(publishedProductVariantFields)) {
+      customPublishedProductVariantFields.push(...publishedProductVariantFields);
+    }
+  }
+}
+```
+
+The function looks for `catalog` key and pushes data from that into exported arrays. In this way, any files in the `reaction-catalog` plugin that import `customPublishedProductFields` or `customPublishedProductVariantFields` will have the full list built from all registered plugins.
+
+To keep track of which plugins are registering what, look at the `name` key in the object. You can save off and export as much information as you need, in whatever format is best.
+
+> A `registerPluginHandler` function may NOT return a Promise. If you need to do something `async` with the data, just save it off for now. Then create and register a `startup` type function, which imports the data you saved off, does the async tasks, and returns a Promise. Startup functions are called immediately after `registerPluginHandler` functions as the app is starting.

--- a/public-docs/running-jest-integration-tests.md
+++ b/public-docs/running-jest-integration-tests.md
@@ -2,7 +2,7 @@
 id: running-jest-integration-tests
 title: Running Jest Integration Tests
 ---
-    
+
 ## Description
 
 We're incrementally moving integration tests out of Meteor+Mocha and into pure Jest tests. Jest integration test files end in `.test.js` and are all located in the `/tests` folder.
@@ -36,7 +36,7 @@ npm run test:integration:watch
 You can use Docker Compose to run a local development container and run tests within it. This gives a more accurate picture of how production code running in a container will behave.
 
 ```sh
-docker-compose run --rm devserver npm run test:integration
+docker-compose run --rm reaction npm run test:integration
 ```
 
 (This will also work with `:watch` suffix for watch mode.)

--- a/public-docs/running-jest-unit-tests.md
+++ b/public-docs/running-jest-unit-tests.md
@@ -2,7 +2,7 @@
 id: running-jest-unit-tests
 title: Running Jest Unit Tests
 ---
-    
+
 ## Description
 
 We're incrementally moving unit tests out of Meteor+Mocha and into pure Jest tests. Jest test files end in `.test.js` and can be anywhere in the Reaction codebase, ideally in the same folder and with the same base filename as the code being tested.
@@ -38,7 +38,7 @@ npm run test:unit:watch
 You can use Docker Compose to run a local development container and run tests within it. This gives a more accurate picture of how production code running in a container will behave.
 
 ```sh
-docker-compose run --rm devserver npm run test:unit
+docker-compose run --rm reaction npm run test:unit
 ```
 
 (This will also work with `:watch` suffix for watch mode.)

--- a/public-docs/writing-jest-integration-tests.md
+++ b/public-docs/writing-jest-integration-tests.md
@@ -23,24 +23,22 @@ GraphQL integration tests are useful for testing things like:
 
 The folder and file structure in `/tests` should match as much as possible the graphql plugin folder structure.
 
-Before writing tests for new queries, make sure the new files are imported in `imports/node-app/devserver` so that the integration test's `TestApp` can find the queries. Import new queries, resolvers, schemas and mutations into their respective file into `imports/node-app/devserver`. For example, a new `schema` file should be imported to `imports/node-app/devserver/schemas.js` and included in the `merge` parameters at the end of the file.
-
 Prior to running the tests in each file, initialize a server, in-memory database, and any collection data you need. Then stop the server when done. The general pattern is something like this:
 
 ```js
-import TestApp from "../TestApp";
+import TestApp from "/imports/test-utils/helpers/TestApp";
 
-let tester;
+let testApp;
 beforeAll(async () => {
-  tester = new TestApp();
-  await tester.start();
+  testApp = new TestApp();
+  await testApp.start();
 });
 
-afterAll(() => tester.stop());
+afterAll(() => testApp.stop());
 
 test("something", async () => {
-  // (1) use tester.collections to write to MongoDB collections to set up initial data state
-  // (2) execute a GraphQL query or mutation using tester.query()() or tester.mutation()()
+  // (1) use testApp.collections to write to MongoDB collections to set up initial data state
+  // (2) execute a GraphQL query or mutation using testApp.query()() or testApp.mutation()()
   // (3) verify the response is as expected and/or verify that the collection data has been changed
   // (4) optionally reset the database if there is a chance it will conflict with the next test in this file
 });

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -96,6 +96,7 @@
     "how-to-get-shop-id-for-client": "How To: Get the shop ID for a client",
     "how-to-manage-app-settings": "How To: Manage App Settings",
     "how-to-rtl": "How To: Add right-to-left language support in the Meteor app",
+    "how-to-share-code-between-plugins": "How To: Share Code Between API Plugins",
     "how-to-store-custom-order-fields": "How To: Store Custom Order Fields",
     "how-to-write-tests-for-plugins": "How To: Write Jest tests for plugins",
     "i18n": "i18n and RTL",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -79,6 +79,7 @@
     "Developer How-To: Reaction API Server": [
       "graphql-create-query",
       "graphql-create-mutation",
+      "how-to-share-code-between-plugins",
       "how-to-create-a-fulfillment-methods-plugin",
       "how-to-create-inventory-plugin",
       "how-to-create-a-payment-provider",

--- a/website/versioned_docs/version-1.14.0/graphql-developing.md
+++ b/website/versioned_docs/version-1.14.0/graphql-developing.md
@@ -47,7 +47,7 @@ The path a GraphQL query or mutation takes is first to a resolver function, whic
 The resolver function:
 - Lives in `/imports/plugins/core/graphql/server/no-meteor/resolvers`
 - Returns a Promise (is async)
-- Transforms IDs (see “IDs in GraphQL”) and data structures (where they don’t match internal data structures)
+- Transforms IDs (see [IDs in GraphQL](#ids-in-graphql)) and data structures (where they don’t match internal data structures)
 - May pull things from the GraphQL context to pass to the plugin function
 - May throw a `Meteor.Error` if anything goes wrong
 - Includes `clientMutationId` in the response (for mutations only)

--- a/website/versioned_docs/version-1.14.0/writing-jest-integration-tests.md
+++ b/website/versioned_docs/version-1.14.0/writing-jest-integration-tests.md
@@ -27,19 +27,19 @@ The folder and file structure in `/tests` should match as much as possible the g
 Prior to running the tests in each file, initialize a server, in-memory database, and any collection data you need. Then stop the server when done. The general pattern is something like this:
 
 ```js
-import TestApp from "../TestApp";
+import TestApp from "/imports/test-utils/helpers/TestApp";
 
-let tester;
+let testApp;
 beforeAll(async () => {
-  tester = new TestApp();
-  await tester.start();
+  testApp = new TestApp();
+  await testApp.start();
 });
 
-afterAll(() => tester.stop());
+afterAll(() => testApp.stop());
 
 test("something", async () => {
-  // (1) use tester.collections to write to MongoDB collections to set up initial data state
-  // (2) execute a GraphQL query or mutation using tester.query()() or tester.mutation()()
+  // (1) use testApp.collections to write to MongoDB collections to set up initial data state
+  // (2) execute a GraphQL query or mutation using testApp.query()() or testApp.mutation()()
   // (3) verify the response is as expected and/or verify that the collection data has been changed
   // (4) optionally reset the database if there is a chance it will conflict with the next test in this file
 });

--- a/website/versioned_docs/version-2.0.0/graphql-create-query.md
+++ b/website/versioned_docs/version-2.0.0/graphql-create-query.md
@@ -12,7 +12,14 @@ The complete Reaction Commerce GraphQL API is created by stitching together doma
 
 See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-developing.md#resolver-mutations-and-queries-vs-plugin-mutations-and-queries)
 
-## Step 3: Define the query in the schema
+## Step 3: Name the query
+
+When choosing a name for the query, there are a few rules to follow:
+- In keeping with general GraphQL best practices, do not use verbs such as "list", "get", or "find" at the beginning of your query name. For example, use "cart" instead of "getCart" and "carts" instead of "listCarts".
+- Prefix with adjectives as necessary to fully describe what the query returns. For example, "anonymousCart" and "accountCart" queries.
+- If there are similar queries that take slightly different parameters, add a suffix to clarify. In most cases, we begin the suffix with "By". For example, "accountCartById" and "accountCartByAccountId".
+
+## Step 4: Define the query in the schema
 
 1. If it doesn't already exist, create `/server/no-meteor/schemas` folder in the plugin, and add an `index.js` file there.
 1. If it doesn't already exist, create `schema.graphql` in `/server/no-meteor/schemas` in the plugin.
@@ -47,7 +54,7 @@ See [Resolver Mutations and Queries vs. Plugin Mutations and Queries](graphql-de
     }
     ```
 
-## Step 4: Create the plugin query file
+## Step 5: Create the plugin query file
 
 1. If it doesn't already exist, create `/server/no-meteor/queries` folder in the plugin, and add an `index.js` file there.
 2. In `/server/no-meteor/queries`, create a file for the query, e.g. `widgets.js` for the `widgets` query. The file should look something like this:
@@ -67,7 +74,7 @@ export default async function widgets(context) {
 }
 ```
 
-## Step 5: Add the plugin query to the queries context
+## Step 6: Add the plugin query to the queries context
 
 In `/server/no-meteor/queries/index.js` in the plugin, import your query and add it to the default export object. Example:
 
@@ -96,7 +103,7 @@ Your plugin query function is now available in the GraphQL context as `context.q
 
 > NOTE: The queries objects from all plugins are merged, so be sure that another plugin does not have a query with the same name. The last one registered with that name will win, and plugins are generally registered in alphabetical order by plugin name. Tip: You can use this to your advantage if you want to override the query function of a core plugin without modifying core code.
 
-## Step 6: Add a test file for your query
+## Step 7: Add a test file for your query
 
 If your query is in a file named `widgets.js`, your Jest tests should be in a file named `widgets.test.js` in the same folder. Initially you can copy and paste the following test:
 
@@ -112,7 +119,7 @@ test("expect to return a Promise that resolves to null", async () => {
 
 This of course should be updated with tests that are appropriate for whatever your query does.
 
-## Step 7: Create the GraphQL query resolver file
+## Step 8: Create the GraphQL query resolver file
 
 1. If it doesn't already exist, create `/server/no-meteor/resolvers` folder in the plugin, and add an `index.js` file there.
 2. If it doesn't already exist, create `/server/no-meteor/resolvers/Query` folder in the plugin, and add an `index.js` file there. "Query" must be capitalized.
@@ -140,7 +147,7 @@ Make adjustments to the resolver function so that it reads and passes along the 
 - Call `context.queries.<queryName>` (your new plugin query) with the necessary arguments, and `await` a response.
 - Return a single document or an array of them using either `getPaginatedResponse` or `xformArrayToConnection` util function.
 
-## Step 8: Register the resolver
+## Step 9: Register the resolver
 
 In `/server/no-meteor/resolvers/Query/index.js` in the plugin, import your query resolver and add it to the default export object. Example:
 
@@ -159,6 +166,18 @@ import Query from "./Query"
 
 export default {
   Query
+};
+```
+
+If you are returning multiple documents (see step #4) you'll need to add an additional export here, `getConnectionTypeResolvers`, in order to be able to query `edges->node`:
+
+```js
+import { getConnectionTypeResolvers } from "@reactioncommerce/reaction-graphql-utils";
+import Query from "./Query"
+
+export default {
+  Query
+  ...getConnectionTypeResolvers("QueryName")
 };
 ```
 
@@ -181,7 +200,7 @@ export default async function register(app) {
 
 Calling your query with GraphQL should now work.
 
-## Step 9: Add a test file for your query resolver
+## Step 10: Add a test file for your query resolver
 
 If your query resolver is in a file named `widgets.js`, your Jest tests should be in a file named `widgets.test.js` in the same folder. Initially you can copy and paste the following test:
 
@@ -204,12 +223,12 @@ test("calls queries.widgets and returns the result", async () => {
 
 This of course should be updated with tests that are appropriate for whatever your query resolver does. For example, verify that all ID and schema transformations happen.
 
-## Step 10: Finish implementing your query
+## Step 11: Finish implementing your query
 
 Adjust the query function and the query resolver function until they work as expected, with tests that prove it. This will likely involve adding additional arguments, ID transformations, permission checks, and MongoDB queries.
 
 Refer to [Developing the GraphQL API](./graphql-developing) for answers to any questions you might have while implementing your mutation.
 
-## Step 11: Update the JSDoc comments
+## Step 12: Update the JSDoc comments
 
 Write/update jsdoc comments for the plugin query function, the query resolver, and any util functions. The resolver function must have `@memberof <PluginName>/GraphQL` in the jsdoc, and the `@name` must be the full GraphQL schema path in quotation marks, e.g., "Query.widgets". (The quotation marks are necessary for the output API documentation to be correct due to the periods.)

--- a/website/versioned_docs/version-2.0.0/graphql-developing.md
+++ b/website/versioned_docs/version-2.0.0/graphql-developing.md
@@ -38,7 +38,7 @@ The path a GraphQL query or mutation takes is first to a resolver function, whic
 The resolver function:
 - Lives in `server/no-meteor/resolvers` in a plugin folder
 - Returns a Promise (is async)
-- Transforms IDs (see “IDs in GraphQL”) and data structures (where they don’t match internal data structures)
+- Transforms IDs (see [IDs in GraphQL](#ids-in-graphql)) and data structures (where they don’t match internal data structures)
 - May pull things from the GraphQL context to pass to the plugin function
 - May throw a `ReactionError` if anything goes wrong
 - Includes `clientMutationId` in the response (for mutations only)

--- a/website/versioned_docs/version-2.0.0/how-to-share-code-between-plugins.md
+++ b/website/versioned_docs/version-2.0.0/how-to-share-code-between-plugins.md
@@ -1,0 +1,98 @@
+---
+id: version-2.0.0-how-to-share-code-between-plugins
+title: How To: Share Code Between API Plugins
+original_id: how-to-share-code-between-plugins
+---
+
+Sometimes you need one API plugin to provide a function to be called by another plugin. There are several different ways to choose from.
+
+| Method                | Pros                                                                                                                                               | Cons                                                                                                                                                                         |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| functionsByType       | - Easy<br>- Supports multiple functions                                                                                                               | - No way to know which plugin registered a function<br>- No way to label a function or provide additional metadata about it<br>- No way to run the functions in a particular order |
+| queries/mutations     | - Easy                                                                                                                                             | - Does not support multiple functions<br>- No way to label a function or provide additional metadata about it<br>- No way to run the functions in a particular order               |
+| registerPluginHandler | - Full control<br>- Can provide dependency/sorting information<br>- Can provide additional metadata<br>- Can track which plugin registered a function | - A bit more work is required to write the handler                                                                                                                           |
+
+In new code, using `registerPluginHandler` is best.
+
+## functionsByType
+
+One simple way to provide a function to another plugin for a specific purpose is to pass it to `registerPlugin` in the `functionsByType` list.
+
+```js
+import funkyFn from "./funkyFn";
+
+await app.registerPlugin({
+  label: "Cart",
+  name: "reaction-cart",
+  functionsByType: {
+    funky: [funkyFn]
+  }
+});
+```
+
+In another plugin, I can then loop through and call all "funky" functions that were registered by other plugins:
+
+```js
+for (const funkyFn of context.getFunctionsOfType("funky")) {
+  // eslint-disable-next-line no-await-in-loop
+  await funkyFn(...args);
+}
+```
+
+Note that the plugin that calls the functions must document what arguments it will provide and what return value and/or side effects it expects.
+
+## queries / mutations
+
+If you only ever want a single function registered, you might choose to use `context.queries` or `context.mutations` instead of `functionsByType`. The idea here is that your plugin can simply document that it expects to find a function named "expireCarts" (for example) on `context.mutations`, and then call `context.mutations.expireCarts`. Just as with `functionsByType`, the plugin that calls the function must document what arguments it will provide and what return value and/or side effects it expects.
+
+> If more than one plugin registers a query or mutation function, the last one registered will win. There is no error or warning thrown. Being able to override these functions in a custom plugin is a feature of Reaction.
+
+> If your query or mutation function is intended to be called only by other plugins, you do not need to add it to your GraphQL schema or create a GraphQL resolver for it.
+
+## registerPluginHandler
+
+The most flexible way to share code, or really any information, between plugins is by creating a `registerPluginHandler` function. This type of function is registered using `functionsByType`:
+
+```js
+import { registerPluginHandler } from "./registration";
+
+await app.registerPlugin({
+  label: "Cart",
+  name: "reaction-cart",
+  functionsByType: {
+    registerPluginHandler: [registerPluginHandler]
+  }
+});
+```
+
+A `registerPluginHandler` function is called multiple times immediately after all plugins are loaded as the app is starting. It is passed the `registerPlugin` options provided by each plugin. The handler is expected to examine the options and save off anything it needs. This means that any plugin can extend the `registerPlugin` options by documenting something it expects to find there.
+
+The typical and recommended pattern is to have a file named `registration.js` in your plugin, in which you not only define and export your `registerPluginHandler`, but also define and export the related data that other files in your plugin need. For example, here is the `reaction-catalog` plugin's `registration.js` file:
+
+```js
+export const customPublishedProductFields = [];
+export const customPublishedProductVariantFields = [];
+
+/**
+ * @summary Will be called for every plugin
+ * @param {Object} options The options object that the plugin passed to registerPlugin
+ * @returns {undefined}
+ */
+export function registerPluginHandler({ catalog }) {
+  if (catalog) {
+    const { publishedProductFields, publishedProductVariantFields } = catalog;
+    if (Array.isArray(publishedProductFields)) {
+      customPublishedProductFields.push(...publishedProductFields);
+    }
+    if (Array.isArray(publishedProductVariantFields)) {
+      customPublishedProductVariantFields.push(...publishedProductVariantFields);
+    }
+  }
+}
+```
+
+The function looks for `catalog` key and pushes data from that into exported arrays. In this way, any files in the `reaction-catalog` plugin that import `customPublishedProductFields` or `customPublishedProductVariantFields` will have the full list built from all registered plugins.
+
+To keep track of which plugins are registering what, look at the `name` key in the object. You can save off and export as much information as you need, in whatever format is best.
+
+> A `registerPluginHandler` function may NOT return a Promise. If you need to do something `async` with the data, just save it off for now. Then create and register a `startup` type function, which imports the data you saved off, does the async tasks, and returns a Promise. Startup functions are called immediately after `registerPluginHandler` functions as the app is starting.

--- a/website/versioned_docs/version-v1.12.0/running-jest-integration-tests.md
+++ b/website/versioned_docs/version-v1.12.0/running-jest-integration-tests.md
@@ -3,7 +3,7 @@ id: version-v1.12.0-running-jest-integration-tests
 title: Running Jest Integration Tests
 original_id: running-jest-integration-tests
 ---
-    
+
 ## Description
 
 We're incrementally moving integration tests out of Meteor+Mocha and into pure Jest tests. Jest integration test files end in `.test.js` and are all located in the `/tests` folder.
@@ -37,7 +37,7 @@ npm run test:integration:watch
 You can use Docker Compose to run a local development container and run tests within it. This gives a more accurate picture of how production code running in a container will behave.
 
 ```sh
-docker-compose run --rm devserver npm run test:integration
+docker-compose run --rm reaction npm run test:integration
 ```
 
 (This will also work with `:watch` suffix for watch mode.)

--- a/website/versioned_docs/version-v1.12.0/running-jest-unit-tests.md
+++ b/website/versioned_docs/version-v1.12.0/running-jest-unit-tests.md
@@ -3,7 +3,7 @@ id: version-v1.12.0-running-jest-unit-tests
 title: Running Jest Unit Tests
 original_id: running-jest-unit-tests
 ---
-    
+
 ## Description
 
 We're incrementally moving unit tests out of Meteor+Mocha and into pure Jest tests. Jest test files end in `.test.js` and can be anywhere in the Reaction codebase, ideally in the same folder and with the same base filename as the code being tested.
@@ -39,7 +39,7 @@ npm run test:unit:watch
 You can use Docker Compose to run a local development container and run tests within it. This gives a more accurate picture of how production code running in a container will behave.
 
 ```sh
-docker-compose run --rm devserver npm run test:unit
+docker-compose run --rm reaction npm run test:unit
 ```
 
 (This will also work with `:watch` suffix for watch mode.)

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -79,6 +79,7 @@
     "Developer How-To: Reaction API Server": [
       "version-2.0.0-graphql-create-query",
       "version-2.0.0-graphql-create-mutation",
+      "version-2.0.0-how-to-share-code-between-plugins",
       "version-2.0.0-how-to-create-a-fulfillment-methods-plugin",
       "version-2.0.0-how-to-create-inventory-plugin",
       "version-2.0.0-how-to-create-a-payment-provider",


### PR DESCRIPTION
Impact: **minor**  
Type: **docs**

- new "How to share code between API plugins" article
- add naming rules to the GraphQL query article
- some small fixes to Jest testing articles