### PR TITLE
(docs): added DCO copy to git style guide docs

### DIFF
--- a/public-docs/git-style-guide.md
+++ b/public-docs/git-style-guide.md
@@ -41,3 +41,17 @@ Examples:
     BREAKING CHANGES: remove Header Blaze template. To migrate to the React component, use HeaderComponent.
 ```
 See more [examples from Angular.js](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#heading=h.8sw072iehlhg).
+
+### Developer Certificate of Origin
+We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) in lieu of a Contributor License Agreement for all contributions to Reaction Commerce open source projects. We request that contributors agree to the terms of the DCO and indicate that agreement by signing all commits made to Reaction Commerce projects by adding a line with your name and email address to every Git commit message contributed:
+```
+Signed-off-by: Jane Doe <jane.doe@example.com>
+```
+
+You can sign your commit automatically with Git by using `git commit -s` if you have your `user.name` and `user.email` set as part of your Git configuration.
+
+We ask that you use your real name (please no anonymous contributions or pseudonyms). By signing your commit you are certifying that you have the right have the right to submit it under the open source license used by that particular Reaction Commerce project. You must use your real name (no pseudonyms or anonymous contributions are allowed.)
+
+We use the [Probot DCO GitHub app](https://github.com/apps/dco) to check for DCO signoffs of every commit.
+
+If you forget to sign your commits, the DCO bot will remind you and give you detailed instructions for how to amend your commits to add a signature.


### PR DESCRIPTION
Resolves #756   
Impact: **minor**  
Type: **docs**

## Issue
Reaction requires all OSS contributors to agree to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) when contributing code back to a project. This info is scattered across several repos but not in the centralized Reaction documentation.  

## Solution & Screenshots
I've included our DCO copy to the Git Styleguide page.

> We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) in lieu of a Contributor License Agreement for all contributions to Reaction Commerce open source projects. We request that contributors agree to the terms of the DCO and indicate that agreement by signing all commits made to Reaction Commerce projects by adding a line with your name and email address to every Git commit message contributed:
> ```sh
> Signed-off-by: Jane Doe <jane.doe@example.com>
> ```

> You can sign your commit automatically with Git by using `git commit -s` if you have your `user.name` and `user.email` set as part of your Git configuration.

> We ask that you use your real name (please no anonymous contributions or pseudonyms). By signing your commit you are certifying that you have the right have the right to submit it under the open source license used by that particular Reaction Commerce project. You must use your real name (no pseudonyms or anonymous contributions are allowed.)

> We use the [Probot DCO GitHub app](https://github.com/apps/dco) to check for DCO signoffs of every commit.

> If you forget to sign your commits, the DCO bot will remind you and give you detailed instructions for how to amend your commits to add a signature.

## Breaking changes
N/A

## Testing
1. Verify this is the best place for this information.
2. Verify there are no typos.