### PR TITLE
docs: update docs related to global plugin permissions

### DIFF
--- a/public-docs/contributing-to-reaction.md
+++ b/public-docs/contributing-to-reaction.md
@@ -129,7 +129,7 @@ The team reviews code quality rules including:
 - **Documentation:** all code added or touched should have proper JSDoc, any new functionality should be documented, as outlined in [JSDoc Style Guide](jsdoc-style-guide.md).
 
 - **Security:**
-  - Code should only be usable by users with the correct roles. Any data published should be filtered to ensure that only users with the correct roles for the correct shops have access to it.
+  - Code should only be usable by users with the correct permissions. Any data published should be filtered to ensure that only users with the correct permissions for the correct shops have access to it.
   - Synk should not fail. Any failing automated tests should not be approved.
 
 - **Performance:** Code should be written with performance in mind. Data publications should only publish data necessary to accomplish the specific goal at hand.

--- a/public-docs/dev-how-do-i.md
+++ b/public-docs/dev-how-do-i.md
@@ -29,7 +29,7 @@ Use `context.accountId` or `context.account`
 await context.checkPermissions(["shipping"], shopId)
 ```
 
-If the user has _any_ of the provided roles, they will be allowed. Otherwise a `ReactionError` will be thrown. Be sure to pass in the correct shop ID, the ID of the shop that owns whatever entity is being fetched or changed.
+If the user has _any_ of the provided permissions, they will be allowed. Otherwise a `ReactionError` will be thrown. Be sure to pass in the correct shop ID, the ID of the shop that owns whatever entity is being fetched or changed.
 
 ## Run plugin code on app startup
 

--- a/public-docs/how-to-manage-app-settings.md
+++ b/public-docs/how-to-manage-app-settings.md
@@ -217,16 +217,8 @@ await app.registerPlugin({
   graphQL: {
     resolvers: {
       ShopSettings: {
-<<<<<<< Updated upstream
         async isMyPluginTurboMode(settings, _, context) {
-          await context.checkPermissions(["admin"], settings.shopId);
-=======
-        isMyPluginTurboMode(settings, args, context) {
-          if (!context.userHasPermission("reaction:plugin-name:entity-name", "read:settings", { args.shopId })) {
-            throw new ReactionError("access-denied", "Access denied");
-          }
-
->>>>>>> Stashed changes
+          await context.validatePermissions("reaction:plugin-name:entity-name", "read:settings", { shopId: PRIMARY_SHOP_ID });
           return settings.isMyPluginTurboMode;
         }
       }

--- a/public-docs/how-to-manage-app-settings.md
+++ b/public-docs/how-to-manage-app-settings.md
@@ -42,7 +42,7 @@ await app.registerPlugin({
 
 Note the following:
 - `globalSettingsConfig` is an object where each key is the name of a setting you want to use. The setting names are not namespaced to your plugin, so be sure that it will be unique among all plugins. For example, this example uses `myPluginLicenseKey` instead of `licenseKey`.
-- `rolesThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
+- `permissionsThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
 - `simpleSchema` is a [simpl-schema](https://github.com/aldeed/simple-schema-js) field definition used to validate the data before it is saved.
 - You can also add a `defaultValue` option if your setting needs a specific value before it is ever set.
 
@@ -98,7 +98,7 @@ Or you can get it in server code:
 const { myPluginLicenseKey } = await context.queries.appSettings(context);
 ```
 
-*Anyone can view all settings by default.* If your setting value should be visible to only certain roles, add a resolver for the field, check the current user's roles in the resolver, and throw a `ReactionError` if they don't have proper permissions:
+*Anyone can view all settings by default.* If your setting value should be visible to only certain permissions, add a resolver for the field, check the current user's permissions in the resolver, and throw a `ReactionError` if they don't have proper permissions:
 
 ```js
 import ReactionError from "@reactioncommerce/reaction-error";
@@ -148,7 +148,7 @@ await app.registerPlugin({
 
 Note the following:
 - `shopSettingsConfig` is an object where each key is the name of a setting you want to use. The setting names are not namespaced to your plugin, so be sure that it will be unique among all plugins. For example, this example uses `isMyPluginTurboMode` instead of `isTurboMode`.
-- `rolesThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
+- `permissionsThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
 - `simpleSchema` is a [simpl-schema](https://github.com/aldeed/simple-schema-js) field definition used to validate the data before it is saved.
 - Set a `defaultValue` if your setting needs a specific value before it is ever set.
 
@@ -205,7 +205,7 @@ Or you can get it in server code:
 const { isMyPluginTurboMode } = await context.queries.appSettings(context, internalShopId);
 ```
 
-*Anyone can view all settings by default.* If your setting value should be visible to only certain roles, add a resolver for the field, check the current user's roles in the resolver, and throw a `ReactionError` if they don't have proper permissions:
+*Anyone can view all settings by default.* If your setting value should be visible to only certain permissions, add a resolver for the field, check the current user's permissions in the resolver, and throw a `ReactionError` if they don't have proper permissions:
 
 ```js
 import ReactionError from "@reactioncommerce/reaction-error";

--- a/public-docs/how-to-manage-app-settings.md
+++ b/public-docs/how-to-manage-app-settings.md
@@ -30,7 +30,7 @@ await app.registerPlugin({
   // ... other options
   globalSettingsConfig: {
     myPluginLicenseKey: {
-      rolesThatCanEdit: ["admin"],
+      rolesThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
       simpleSchema: {
         type: String,
         min: 10
@@ -42,7 +42,7 @@ await app.registerPlugin({
 
 Note the following:
 - `globalSettingsConfig` is an object where each key is the name of a setting you want to use. The setting names are not namespaced to your plugin, so be sure that it will be unique among all plugins. For example, this example uses `myPluginLicenseKey` instead of `licenseKey`.
-- `rolesThatCanEdit` must be an array of roles. A user must have any ONE of these roles to update this setting value.
+- `rolesThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
 - `simpleSchema` is a [simpl-schema](https://github.com/aldeed/simple-schema-js) field definition used to validate the data before it is saved.
 - You can also add a `defaultValue` option if your setting needs a specific value before it is ever set.
 
@@ -110,8 +110,16 @@ await app.registerPlugin({
   graphQL: {
     resolvers: {
       GlobalSettings: {
+<<<<<<< Updated upstream
         async myPluginLicenseKey(settings, _, context) {
           await context.checkPermissions(["admin"]);
+=======
+        myPluginLicenseKey(settings, _, context) {
+          if (!context.userHasPermission("reaction:plugin-name:entity-name", "read:settings", { shopId: PRIMARY_SHOP_ID })) {
+            throw new ReactionError("access-denied", "Access denied");
+          }
+
+>>>>>>> Stashed changes
           return settings.myPluginLicenseKey;
         }
       }
@@ -136,7 +144,7 @@ await app.registerPlugin({
   shopSettingsConfig: {
     isMyPluginTurboMode: {
       defaultValue: false,
-      rolesThatCanEdit: ["admin"],
+      rolesThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
       simpleSchema: {
         type: String,
         min: 10
@@ -148,7 +156,7 @@ await app.registerPlugin({
 
 Note the following:
 - `shopSettingsConfig` is an object where each key is the name of a setting you want to use. The setting names are not namespaced to your plugin, so be sure that it will be unique among all plugins. For example, this example uses `isMyPluginTurboMode` instead of `isTurboMode`.
-- `rolesThatCanEdit` must be an array of roles. A user must have any ONE of these roles to update this setting value.
+- `rolesThatCanEdit` must be an array of permissions. A user must belong to a group that has any ONE of these permissions to update this setting value.
 - `simpleSchema` is a [simpl-schema](https://github.com/aldeed/simple-schema-js) field definition used to validate the data before it is saved.
 - Set a `defaultValue` if your setting needs a specific value before it is ever set.
 
@@ -217,8 +225,16 @@ await app.registerPlugin({
   graphQL: {
     resolvers: {
       ShopSettings: {
+<<<<<<< Updated upstream
         async isMyPluginTurboMode(settings, _, context) {
           await context.checkPermissions(["admin"], settings.shopId);
+=======
+        isMyPluginTurboMode(settings, args, context) {
+          if (!context.userHasPermission("reaction:plugin-name:entity-name", "read:settings", { args.shopId })) {
+            throw new ReactionError("access-denied", "Access denied");
+          }
+
+>>>>>>> Stashed changes
           return settings.isMyPluginTurboMode;
         }
       }

--- a/public-docs/how-to-manage-app-settings.md
+++ b/public-docs/how-to-manage-app-settings.md
@@ -30,7 +30,7 @@ await app.registerPlugin({
   // ... other options
   globalSettingsConfig: {
     myPluginLicenseKey: {
-      rolesThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
+      permissionsThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
       simpleSchema: {
         type: String,
         min: 10
@@ -110,16 +110,8 @@ await app.registerPlugin({
   graphQL: {
     resolvers: {
       GlobalSettings: {
-<<<<<<< Updated upstream
         async myPluginLicenseKey(settings, _, context) {
-          await context.checkPermissions(["admin"]);
-=======
-        myPluginLicenseKey(settings, _, context) {
-          if (!context.userHasPermission("reaction:plugin-name:entity-name", "read:settings", { shopId: PRIMARY_SHOP_ID })) {
-            throw new ReactionError("access-denied", "Access denied");
-          }
-
->>>>>>> Stashed changes
+          await context.validatePermissions("reaction:plugin-name:entity-name", "read:settings", { shopId: PRIMARY_SHOP_ID });
           return settings.myPluginLicenseKey;
         }
       }

--- a/public-docs/how-to-manage-app-settings.md
+++ b/public-docs/how-to-manage-app-settings.md
@@ -136,7 +136,7 @@ await app.registerPlugin({
   shopSettingsConfig: {
     isMyPluginTurboMode: {
       defaultValue: false,
-      rolesThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
+      permissionsThatCanEdit: ["reaction:plugin-name:entity-name/update:settings"],
       simpleSchema: {
         type: String,
         min: 10

--- a/public-docs/permissions.md
+++ b/public-docs/permissions.md
@@ -3,8 +3,6 @@ id: permissions
 title: Permissions
 ---
 
-The [alanning:roles](https://github.com/alanning/meteor-roles) Meteor package provides Reaction permissions support.
-
 ## Permission Groups
 
 Permission Groups are are way to grant multiple users a group of permissions. The Accounts Dashboard provides a way to create a group and add users to them.


### PR DESCRIPTION
Update docs related to global plugin setting to go along with https://github.com/reactioncommerce/reaction/pull/6031