### PR TITLE
docs: update reaction development platform name throughout docs

### DIFF
--- a/docs/architecture/decisions/0003-tutorial-deprecation-plan.md
+++ b/docs/architecture/decisions/0003-tutorial-deprecation-plan.md
@@ -26,7 +26,7 @@ Readers need an easy way to find and distinguish between pre-2.0 and post-2.0 co
         - https://docs.reactioncommerce.com/docs/1.16.0/how-to-create-a-custom-homepage
         - https://docs.reactioncommerce.com/docs/1.16.0/extending-product-schema-location-map
         - https://docs.reactioncommerce.com/docs/1.16.0/how-to-rtl
-        - Swag Shop: 
+        - Swag Shop:
             - https://docs.reactioncommerce.com/docs/1.16.0/swag-shop-tutorial
             - https://docs.reactioncommerce.com/docs/1.16.0/swag-shop-collecting-requirements
             - https://docs.reactioncommerce.com/docs/1.16.0/swag-shop-initialization
@@ -36,7 +36,7 @@ Readers need an easy way to find and distinguish between pre-2.0 and post-2.0 co
 
 ## Use a single installation instruction link moving forward
 
-- Use the Reaction Platform installation instructions across all READMEs: https://docs.reactioncommerce.com/docs/installation-reaction-platform
+- Use the Reaction Development Platform installation instructions across all READMEs: https://docs.reactioncommerce.com/docs/installation-reaction-platform
     - Reaction
     - Example Storefront
     - With the exception of the Platform itself, which will need more in-depth instructions for those who also want to develop on the Platform.

--- a/public-docs/getting-started-developing-with-reaction.md
+++ b/public-docs/getting-started-developing-with-reaction.md
@@ -5,7 +5,7 @@ title: Getting Started As a Developer
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Platform instructions](https://github.com/reactioncommerce/reaction-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
 
 Read [Developing In Docker](installation-docker-development) to understand how to do development on a multi-service application like Reaction.
 

--- a/public-docs/graphql-intro.md
+++ b/public-docs/graphql-intro.md
@@ -5,7 +5,7 @@ title: Tutorial: Getting started with GraphQL
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Platform instructions](https://github.com/reactioncommerce/reaction-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
 
 Make sure you are on Reaction 3.0.0 or above.
 

--- a/public-docs/installation-docker-development.md
+++ b/public-docs/installation-docker-development.md
@@ -8,7 +8,7 @@ We recommend doing all development in Docker containers using Docker Compose con
 
 ## Getting Started
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Platform instructions](https://github.com/reactioncommerce/reaction-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
 
 ## Alias Docker Compose Commands
 
@@ -23,7 +23,7 @@ Then wherever these instructions say `docker-compose`, you can type only `dc`, a
 
 ## Run the Reaction API
 
-> NOTE: If you also need to run the storefront or just want to simplify this a bit, consider using [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), which will do all of this and more.
+> NOTE: If you also need to run the storefront or just want to simplify this a bit, consider using [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), which will do all of this and more.
 
 Thanks to the Dockerfiles and `docker-compose.yml` file in the root of the main Reaction project repo, you can start all necessary services in Docker containers by running:
 

--- a/public-docs/release-process.md
+++ b/public-docs/release-process.md
@@ -7,7 +7,7 @@ title: Release Guide
 
 The [Reaction engineering team and invited community collaborators](https://github.com/orgs/reactioncommerce/people) creates new release branches of Reaction.
 
-> A "Reaction Release" consists of coordinated releases in four repositories: [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), [Reaction](https://github.com/reactioncommerce/reaction), [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
+> A "Reaction Release" consists of coordinated releases in four repositories: [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), [Reaction](https://github.com/reactioncommerce/reaction), [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
 
 ## Preparing each project
 
@@ -32,7 +32,7 @@ The [Reaction engineering team and invited community collaborators](https://gith
 
             Reaction v{X.X.X} adds {major|minor} features and performance enhancements, fixes bugs and contains no breaking changes since v{X.X.X - 1version}.
 
-            This release is being coordinated with [Reaction Platform](https://github.com/reactioncommerce/reaction-platform) and is designed to work with `v{X.X.X}` of [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra) and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
+            This release is being coordinated with [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform) and is designed to work with `v{X.X.X}` of [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra) and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
 
             ## Notable changes
 
@@ -68,7 +68,7 @@ The [Reaction engineering team and invited community collaborators](https://gith
 
             Thanks to @{outside-contributor} for contributing to this release! 🎉
 
-        This is an example of a `CHANGELOG` for the `Reaction` project, please update accordingly if this is for `Reaction Platform`, `Reaction Hydra`, or `Example Storefront`.
+        This is an example of a `CHANGELOG` for the `Reaction` project, please update accordingly if this is for `Reaction Development Platform`, `Reaction Hydra`, or `Example Storefront`.
 
     - Creating release notes on a project with no changes, just a version bump to keep the project in sync
 
@@ -80,21 +80,21 @@ The [Reaction engineering team and invited community collaborators](https://gith
 
             # v{X.X.X}
 
-            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), [Reaction](https://github.com/reactioncommerce/reaction), and [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra).
+            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), [Reaction](https://github.com/reactioncommerce/reaction), and [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra).
 
         ### Reaction
 
             # v{X.X.X}
 
-            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
+            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), [Reaction Hydra](https://github.com/reactioncommerce/reaction-hydra), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
 
         ### Reaction Hydra
 
             # v{X.X.X}
 
-            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), [Reaction](https://github.com/reactioncommerce/reaction), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
+            This is a {major|minor|patch} version update to keep this projects versioning coordinated with [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), [Reaction](https://github.com/reactioncommerce/reaction), and [Example Storefront](https://github.com/reactioncommerce/example-storefront).
 
-        ### Reaction Platform
+        ### Reaction Development Platform
 
             # v{X.X.X}
 
@@ -104,7 +104,7 @@ The [Reaction engineering team and invited community collaborators](https://gith
 - Ask QA for a review
 - `Reaction`, `Reaction Hyrda`, and `Example Storefront` can be merged as soon as they are approved.
 
-Do not merge `Reaction Platform` at this time.
+Do not merge `Reaction Development Platform` at this time.
 
 ## Creating releases for `Reaction`, `Reaction Hydra`, and `Example Storefront`
 
@@ -119,16 +119,16 @@ Once `Reaction`, `Reaction Hydra`, and `Example Storefront` have been merged, an
 - Save the release as a draft, and have your fellow release manager (or anyone) take a look to make sure everything, but especially the tag, looks correct. Once published, the tag cannot be changed.
 - If everything looks good, `Publish release`
 
-## Creating a release for `Reaction Platform`
+## Creating a release for `Reaction Development Platform`
 
-Once `Reaction`, `Reaction Hydra`, and `Example Storefront` have been released, we can update `Reaction Platform` to use these new releases, and release the platform.
+Once `Reaction`, `Reaction Hydra`, and `Example Storefront` have been released, we can update `Reaction Development Platform` to use these new releases, and release the platform.
 
 1. Update `[config.mk](http://config.mk)` to use the latest version numbers in the `define SUBPROJECT_REPOS` block of code:
 
     ![](reaction-platform_config_mk_at_master__reactioncommerce_reaction-platform-63e424d3-0c72-4328-9765-838441aacf0f.png)
 
 2. Ask QA for a review of the platform, using the updated releases
-3. `Reaction Platform` can now be merged as soon as they are approved.
+3. `Reaction Development Platform` can now be merged as soon as they are approved.
 4. Next, create a release using the same instructions as above.
 5. Once published, the release is official! Send a notice to the engineering channel to give everyone a heads up!
 

--- a/public-docs/upgrading.md
+++ b/public-docs/upgrading.md
@@ -24,9 +24,9 @@ This article explains the differences between Reaction 2.x releases and 3.x rele
 
 The following is a summary of all of the environment variables needed by all Reaction services, and how they changed from 2.9.1 to 3.0.0.
 
-In a development environment, if you clone a new Reaction Platform, check out the 3.0.0 branch, and run `make`, all of these should be handled automatically for you.
+In a development environment, if you clone a new Reaction Development Platform, check out the 3.0.0 branch, and run `make`, all of these should be handled automatically for you.
 
-In a development environment, if you reuse a Reaction Platform folder that has already been used to run Reaction 2.x, **you must make some manual adjustments to the `.env` files in each project**. Reaction Platform runs the `bin/setup` script in each project, but this script will not overwrite existing variables to new values or remove variables that are no longer needed. This is why we recommend a separate Reaction Platform clone for 3.x, but if you must switch between 2.x and 3.x in the same Reaction Platform, then you should **manually copy `.env.example` to `.env` in every project, completely overwriting the `.env` file contents**. If you have intentionally customized some variables, you can redo your customizations after copying over the entire `.env.example` file.
+In a development environment, if you reuse a Reaction Development Platform folder that has already been used to run Reaction 2.x, **you must make some manual adjustments to the `.env` files in each project**. Reaction Development Platform runs the `bin/setup` script in each project, but this script will not overwrite existing variables to new values or remove variables that are no longer needed. This is why we recommend a separate Reaction Development Platform clone for 3.x, but if you must switch between 2.x and 3.x in the same Reaction Development Platform, then you should **manually copy `.env.example` to `.env` in every project, completely overwriting the `.env` file contents**. If you have intentionally customized some variables, you can redo your customizations after copying over the entire `.env.example` file.
 
 In a deployed environment, you can go service by service and start from your 2.x variables, adding, removing, or changing some of them as described below.
 
@@ -162,7 +162,7 @@ See [Updating a 2.x API plugin to work with Reaction API 3.x](./devs-update-cust
 
 ## Notes for Developers
 
-- We highly recommend that you clone `reaction-platform` into a separate folder for 3.x. When you run the `git clone` command, add `reaction-platform3` or something similar at the end, and it will clone into a folder with that name instead of defaulting to the repo name. This way you will avoid having to change your `.env` file back and forth if you switch from 2.x to 3.x. Just run 2.x from one the `reaction-platform2` folder and 3.x from the `reaction-platform3` folder.
+- We highly recommend that you clone `reaction-development-platform` into a separate folder for 3.x. When you run the `git clone` command, add `reaction-development-platform3` or something similar at the end, and it will clone into a folder with that name instead of defaulting to the repo name. This way you will avoid having to change your `.env` file back and forth if you switch from 2.x to 3.x. Just run 2.x from one the `reaction-development-platform2` folder and 3.x from the `reaction-development-platform3` folder.
 - Every project now has a `.nvmrc` file listing the proper expected version of NodeJS. Always run `nvm use` after you `cd` to any project directory. If prompted, run the `nvm install` command that is shown.
   - If you don't have the `nvm` command, go here to download NVM: [https://github.com/nvm-sh/nvm](https://github.com/nvm-sh/nvm)
   - There are [shell extensions](https://github.com/nvm-sh/nvm/blob/master/README.md#deeper-shell-integration) you can install to automatically do `nvm use` whenever you `cd` to a directory that has a `.nvmrc` file.

--- a/website/versioned_docs/version-2.9.1/getting-started-developing-with-reaction.md
+++ b/website/versioned_docs/version-2.9.1/getting-started-developing-with-reaction.md
@@ -6,7 +6,7 @@ original_id: getting-started-developing-with-reaction
 
 ## Install
 
-To install Reaction version 2.0 and above, follow these [Reaction Platform instructions](installation-reaction-platform.md).
+To install Reaction version 2.0 and above, follow these [Reaction Development Platform instructions](installation-reaction-platform.md).
 
 > Looking for installation instructions for older versions of Reaction? Follow these instructions to install version 1.16 for [Windows](/docs/1.16.0/installation-windows), [Mac OSX](/docs/1.16.0/installation-osx), [Linux](/docs/1.16.0/installation-linux).
 

--- a/website/versioned_docs/version-2.9.1/installation-docker-development.md
+++ b/website/versioned_docs/version-2.9.1/installation-docker-development.md
@@ -28,7 +28,7 @@ Then wherever these instructions say `docker-compose`, you can type only `dc`, a
 
 ## Run the Reaction API
 
-> NOTE: If you also need to run the storefront or just want to simplify this a bit, consider using [Reaction Platform](https://github.com/reactioncommerce/reaction-platform), which will do all of this and more.
+> NOTE: If you also need to run the storefront or just want to simplify this a bit, consider using [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform), which will do all of this and more.
 
 Thanks to the Dockerfiles and `docker-compose.yml` file in the root of the main Reaction project repo, you can start all necessary services in Docker containers by running:
 

--- a/website/versioned_docs/version-2.9.1/installation-reaction-platform.md
+++ b/website/versioned_docs/version-2.9.1/installation-reaction-platform.md
@@ -1,12 +1,12 @@
 ---
 id: version-2.9.1-installation-reaction-platform
-title: Install with Reaction Platform
-sidebar_label: Install with Reaction Platform
+title: Install with Reaction Development Platform
+sidebar_label: Install with Reaction Development Platform
 original_id: installation-reaction-platform
 ---
 
 
-The Reaction Platform is the easiest way to run the entire suite of Reaction services at once, as of Reaction version 2.0. The Platform installs and runs the entire suite of Reaction services in these directories:
+The Reaction Development Platform is the easiest way to run the entire suite of Reaction services at once, as of Reaction version 2.0. The Platform installs and runs the entire suite of Reaction services in these directories:
 
 | Directory                                                                                  | Services                                   |
 | ------------------------------------------------------------------------------------------ | ------------------------------------------ |
@@ -25,7 +25,7 @@ The Reaction Platform is the easiest way to run the entire suite of Reaction ser
 ##### Recommended settings for Docker for Mac, Windows and Linux
 - Minimum 4GB of RAM and 4CPUs, for better performance allocate 4GB+ and 4CPUs+. For instructions visit the advanced section of the [Docker for Mac Getting Started guide](https://docs.docker.com/docker-for-mac/).
 
-> **Windows**: Reaction Platform has not been fully tested on Windows at this time.
+> **Windows**: Reaction Development Platform has not been fully tested on Windows at this time.
 
 > **Linux**: Docker Compose is included when installing Docker on Mac and Windows, but will need to be installed separately on Linux.
 
@@ -33,16 +33,16 @@ The Reaction Platform is the easiest way to run the entire suite of Reaction ser
   - Increase the memory and CPU allocated to Docker in the Docker settings. We recommend at least 4 GiB memory. The default values are usually not sufficient to run the full Reaction system. See the [troubleshooting-development](./troubleshooting-development#memory-errors-or-errors-about-meteor-rawlogs) article for more information.
   - Make sure you are not running any applications on the default ports: `3000`, `4000`, `4444`, `4445`, `5555`, `5432`, and `27017`.
 
-3. Clone [**Reaction Platform**](https://github.com/reactioncommerce/reaction-platform)
+3. Clone [**Reaction Development Platform**](https://github.com/reactioncommerce/reaction-development-platform)
 
 ```sh
-git clone git@github.com:reactioncommerce/reaction-platform.git
+git clone git@github.com:reactioncommerce/reaction-development-platform.git
 ```
 
 4. Now you're ready to install. Run this command to bootstrap and start all of the services:
 
 ```sh
-cd reaction-platform
+cd reaction-development-platform
 make
 ```
 
@@ -106,7 +106,7 @@ docker-compose logs -f
 | [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra): oryd/hydra         | [localhost:4444](localhost:4444)                              |
 | [`example-storefront`](https://github.com/reactioncommerce/example-storefront) | [localhost:4000](localhost:4000)                              |
 
-7. Congrats 🎉  Now you're running the entire suite of Reaction Platform services and ready to start developing.
+7. Congrats 🎉  Now you're running the entire suite of Reaction Development Platform services and ready to start developing.
 
 **Note:** To login into the Operator UI use the credentials found in the [env.example](https://github.com/reactioncommerce/reaction/blob/v2.9.1/.env.example#L11-L12) file.
 
@@ -114,17 +114,17 @@ docker-compose logs -f
 
 If you are upgrading from Reaction 1.x, follow these steps:
 
-1. Pull locally the latest changes from the [reaction-platform repository](https://github.com/reactioncommerce/reaction-platform)
+1. Pull locally the latest changes from the [reaction-development-platform repository](https://github.com/reactioncommerce/reaction-development-platform)
 
 ```sh
-cd reaction-platform
+cd reaction-development-platform
 git pull origin trunk
 ```
 
 2. Pull locally the latest changes from the [reaction repository](https://github.com/reactioncommerce/reaction) and update packages
 
 ```sh
-cd reaction-platform/reaction
+cd reaction-development-platform/reaction
 git pull origin trunk
 docker-compose run --rm reaction npm install
 ```
@@ -132,7 +132,7 @@ docker-compose run --rm reaction npm install
 3. Pull locally the latest changes from the [example-storefront repository](https://github.com/reactioncommerce/example-storefront) and update packages
 
 ```sh
-cd reaction-platform/example-storefront
+cd reaction-development-platform/example-storefront
 git pull origin trunk
 docker-compose run --rm web yarn install
 ```
@@ -140,7 +140,7 @@ docker-compose run --rm web yarn install
 4. You are now ready to start the upgraded Reaction. Run this command to bootstrap and start all of the services:
 
 ```sh
-cd reaction-platform
+cd reaction-development-platform
 make
 ```
 
@@ -154,13 +154,13 @@ If you are upgrading from an older 2.0 release candidate, follow the steps liste
 
 With Reaction 2.0 release, we introduced a `develop` branch at both the [Reaction](https://github.com/reactioncommerce/reaction) and the [example-storefront](https://github.com/reactioncommerce/example-storefront) repositories. This branch contains all the latest changes, while `trunk`  is our stable branch.
 
-## Developing with Reaction Platform
+## Developing with Reaction Development Platform
 
 Once you've bootstrapped the entire Reaction development in Docker, use `make start` to start all containers.
 
-### Reaction Platform commands
+### Reaction Development Platform commands
 
-Run these commands from the `reaction-platform` directory:
+Run these commands from the `reaction-development-platform` directory:
 
 | Command                    | Description                                                                           |
 | -------------------------- | ------------------------------------------------------------------------------------- |
@@ -171,7 +171,7 @@ Run these commands from the `reaction-platform` directory:
 | `make clean`               | Removes all containers, networks, and volumes. Any volume data will be lost.          |
 | `make init-<project-name>` | Example: `make init-example-storefront`. Does clone/setup for a single project. |
 
-Learn more about [Reaction Platform](https://github.com/reactioncommerce/reaction-platform).
+Learn more about [Reaction Development Platform](https://github.com/reactioncommerce/reaction-development-platform).
 
 ### Git
 

--- a/website/versioned_docs/version-2.9.1/intro.md
+++ b/website/versioned_docs/version-2.9.1/intro.md
@@ -4,7 +4,7 @@ original_id: intro
 title: Introduction
 ---
 
-This is the home for documentation for <a href="http://github.com/reactioncommerce/reaction">Reaction</a>, <a href="https://github.com/reactioncommerce/reaction-platform">Reaction Platform</a>, <a href="https://github.com/reactioncommerce/example-storefront/">Example Storefront</a> and other supporting services.
+This is the home for documentation for <a href="http://github.com/reactioncommerce/reaction">Reaction</a>, <a href="https://github.com/reactioncommerce/reaction-development-platform">Reaction Development Platform</a>, <a href="https://github.com/reactioncommerce/example-storefront/">Example Storefront</a> and other supporting services.
 
 Reaction is a GraphQL API and a Reaction Admin app. The Example Storefront is Reaction Commerce’s headless ecommerce storefront, built using Next.js, GraphQL, React, Apollo Client and the commerce-focused React UI components provided in the <a href="http://designsystem.reactioncommerce.com/">Example Storefront Component Library</a>.
 

--- a/website/versioned_docs/version-2.9.1/understanding-hydra-setup.md
+++ b/website/versioned_docs/version-2.9.1/understanding-hydra-setup.md
@@ -5,7 +5,7 @@ sidebar_label: Understanding Hydra Auth Setup
 original_id: understanding-hydra-auth-setup
 ---
 
-As of version 2.0, Reaction Commerce uses [ORY Hydra](https://github.com/ory/hydra) (Hydra), an OAuth 2.0 and Open ID Connect Provider, for authentication across the `reaction` and `example-storefront` apps. 
+As of version 2.0, Reaction Commerce uses [ORY Hydra](https://github.com/ory/hydra) (Hydra), an OAuth 2.0 and Open ID Connect Provider, for authentication across the `reaction` and `example-storefront` apps.
 
 Hydra issues access, refresh, and ID Tokens, but does not offer user management (like user sign up, log in, password reset flows). Instead, Hydra uses redirects and a REST API to connect with an existing identity provider.
 
@@ -15,7 +15,7 @@ At a high level, when a user of the storefront logs in, the user is redirected f
 
 Read more about Hydra, OAuth2 and OpenID Connect on Hydra docs [here](https://www.ory.sh/docs/guides/master/hydra/).
 
-To get started with [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra), make sure you have upgraded to Reaction version 2.0. The easiest way to install and run all the application is to use [`reaction-platform`](https://github.com/reactioncommerce/reaction-platform).
+To get started with [`reaction-hydra`](https://github.com/reactioncommerce/reaction-hydra), make sure you have upgraded to Reaction version 2.0. The easiest way to install and run all the application is to use [`reaction-development-platform`](https://github.com/reactioncommerce/reaction-development-platform).
 
 ## Setting up the client
 


### PR DESCRIPTION
Update the docs to address the renaming of `Reaction Platform` to `Reaction Development Platform`.