### PR TITLE
Fix link to reaction platform installation page

### DIFF
--- a/website/versioned_docs/version-2.9.1/getting-started-developing-with-reaction.md
+++ b/website/versioned_docs/version-2.9.1/getting-started-developing-with-reaction.md
@@ -6,7 +6,7 @@ original_id: getting-started-developing-with-reaction
 
 ## Install
 
-To install Reaction version 2.0 and above, follow these [Reaction Platform instructions](installation-reaction-platform.md).
+To install Reaction version 2.0 and above, follow these [Reaction Platform instructions](installation-reaction-platform).
 
 > Looking for installation instructions for older versions of Reaction? Follow these instructions to install version 1.16 for [Windows](/docs/1.16.0/installation-windows), [Mac OSX](/docs/1.16.0/installation-osx), [Linux](/docs/1.16.0/installation-linux).
 


### PR DESCRIPTION
Impact: **minor**
Type: **bugfix**

## Issue
Link to the Reaction Platform installation instructions page is not functioning, rather it leads to a 404 page.

## Solution & Screenshots
Fix the link.

## Breaking changes
n/a

## Testing
1. Open the docs
2. Go to https://docs.reactioncommerce.com/docs/getting-started-developing-with-reaction
3. Click the Reaction Platform instructions link
4. See that it takes you to the correct page and not a 404 page.
