### PR TITLE
Update Broken Link for Resolver Map

### DIFF
--- a/public-docs/graphql-resolvers-file-structure.md
+++ b/public-docs/graphql-resolvers-file-structure.md
@@ -6,7 +6,7 @@ title: Understanding the Resolvers File Structure
 As you may have seen, all core plugins use a similar file and folder structure for resolvers, and we recommend that you do the same for custom plugins. The basic premise is to have the folders and files reflect the hierarchy of the `resolvers` object, making it easier to find the resolver code you're looking for.
 
 Before explaining the file structure, there are two concepts you need to fully understand:
-- [What is a resolver map?](https://www.apollographql.com/docs/apollo-server/essentials/data.html#resolver-map)
+- [What is a resolver map?](https://www.apollographql.com/docs/apollo-server/data/data/#resolver-map)
 - Each Reaction plugin can register its own resolver map, and all registered `resolvers` objects are then deep merged together into a single object, which is what is provided to the GraphQL library as the full resolver map. If two plugins have conflicting terminal nodes in the resolver tree, the last one registered wins. Currently plugins are loaded in alphabetical order by plugin folder name, grouped by "core" first, then "included", and then "custom".
 
 Now, let's take the core payments plugin as an example. Here is what a GraphQL resolver map for the payments plugin would look like in a single file:


### PR DESCRIPTION
existing link is broken and should  to be updated to
https://www.apollographql.com/docs/apollo-server/data/data/#resolver-map

Resolves #issueNumber
Impact: **breaking|critical|major|minor**
Type: **feature|bugfix|performance|test|style|refactor|docs|chore**

## Issue


## Solution & Screenshots


## Breaking changes


## Testing
1. List the steps needed for testing your change in this section.
2. Assume that testers already know how to start the app, and do the basic setup tasks.
3. Be detailed enough that someone can work through it without being too granular

More detail for what each of these sections should include are available in our [Contributing Docs](https://docs.reactioncommerce.com/reaction-docs/trunk/contributing-to-reaction)
