### PR TITLE
fix: link to v3.0.0 tag rather than branch

### DIFF
--- a/public-docs/getting-started-developing-with-reaction.md
+++ b/public-docs/getting-started-developing-with-reaction.md
@@ -5,7 +5,7 @@ title: Getting Started As a Developer
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 Read [Developing In Docker](installation-docker-development) to understand how to do development on a multi-service application like Reaction.
 

--- a/public-docs/graphql-intro.md
+++ b/public-docs/graphql-intro.md
@@ -5,7 +5,7 @@ title: Tutorial: Getting started with GraphQL
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 Make sure you are on Reaction 3.0.0 or above.
 

--- a/public-docs/installation-docker-development.md
+++ b/public-docs/installation-docker-development.md
@@ -8,7 +8,7 @@ We recommend doing all development in Docker containers using Docker Compose con
 
 ## Getting Started
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 ## Alias Docker Compose Commands
 

--- a/website/versioned_docs/version-3.0.0/graphql-intro.md
+++ b/website/versioned_docs/version-3.0.0/graphql-intro.md
@@ -6,7 +6,7 @@ original_id: graphql-intro
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 Make sure you are on Reaction 3.0.0 or above.
 

--- a/website/versioned_docs/version-3.0.0/installation-docker-development.md
+++ b/website/versioned_docs/version-3.0.0/installation-docker-development.md
@@ -9,7 +9,7 @@ We recommend doing all development in Docker containers using Docker Compose con
 
 ## Getting Started
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 ## Alias Docker Compose Commands
 


### PR DESCRIPTION
Fixes several links that were linking to the now deleted
release-v3.0.0 branch. Links have been updated to link to
v3.0.0 git tag now.