### PR TITLE
fix: use git tag instead of branch versioned docs

### DIFF
--- a/website/versioned_docs/version-3.0.0/getting-started-developing-with-reaction.md
+++ b/website/versioned_docs/version-3.0.0/getting-started-developing-with-reaction.md
@@ -6,7 +6,7 @@ original_id: getting-started-developing-with-reaction
 
 ## Install
 
-To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/release-v3.0.0#prerequisites).
+To install Reaction for development, testing, or demonstration on your own computer, follow these [Reaction Development Platform instructions](https://github.com/reactioncommerce/reaction-development-platform/tree/v3.0.0#prerequisites).
 
 Read [Developing In Docker](installation-docker-development) to understand how to do development on a multi-service application like Reaction.
 


### PR DESCRIPTION
Fixes a spot in the versioned docs that uses the release-v3.0.0 branch instead of the v3.0.0 tag.