### PR TITLE
Fix docs not starting

### DIFF
--- a/website/versioned_docs/version-3.0.0/graphql-create-mutation.md
+++ b/website/versioned_docs/version-3.0.0/graphql-create-mutation.md
@@ -1,6 +1,7 @@
 ---
-id: graphql-create-mutation
+id: version-3.0.0-graphql-create-mutation
 title: How To: Create a new GraphQL mutation
+original_id: graphql-create-mutation
 ---
 
 ## Step 1: Identify which plugin owns the mutation

--- a/website/versioned_docs/version-3.0.0/graphql-create-query.md
+++ b/website/versioned_docs/version-3.0.0/graphql-create-query.md
@@ -1,6 +1,7 @@
 ---
-id: graphql-create-query
+id: version-3.0.0-graphql-create-query
 title: How To: Create a new GraphQL query
+original_id: graphql-create-query
 ---
 
 ## Step 1: Identify which plugin owns the query


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #933
Impact: **breaking**
Type: **bugfix|chore**

## Issue
Docusaurus refuses to start because `website/versioned_docs/version-3.0.0/graphql-create-mutation.md` and `website/versioned_docs/version-3.0.0/graphql-create-query.md` are missing `original_id`s.

## Breaking changes
`id`s and `original_id`s were updated in both files.

## Testing
1. Start the docs.
2. See no errors.