### PR TITLE
Deprecate Social Settings page

### DIFF
--- a/website/versioned_docs/version-2.0.0/social-settings.md
+++ b/website/versioned_docs/version-2.0.0/social-settings.md
@@ -1,0 +1,10 @@
+---
+id: version-2.0.0-social-settings
+title: Social settings
+original_id: social-settings
+---
+
+# Deprecated feature
+
+Reaction Commerce's built-in integration with social networks has been deprecated since version 2.0 and is not available anymore. This article is available as an archive by selecting any earlier version.
+


### PR DESCRIPTION
Signed-off-by: Loan Laux <loan@outgrow.io>

Resolves #795
Impact: **major**
Type: **docs|chore**

## Issue
The Social Settings page isn't up to date anymore. @kieckhafer agreed that we can simply deprecate it.