### PR TITLE
[fix] componenets -> components

### DIFF
--- a/public-docs/styleguide.md
+++ b/public-docs/styleguide.md
@@ -155,7 +155,7 @@ Naming methods:
 
 Working with methods:
 
-- Avoid ternary operators and one-line `if` statements (except in React componenets)
+- Avoid ternary operators and one-line `if` statements (except in React components)
 - Use parenthesis around all method arguments:
 
 ```js


### PR DESCRIPTION

Impact: minor
Type: docs

## Issue
Typo

## Solution & Screenshots
```diff
- Avoid ternary operators and one-line `if` statements (except in React componenets)
+ Avoid ternary operators and one-line `if` statements (except in React components)
```

## Breaking changes
None

## Testing
None
