### PR TITLE
fix: corrected GA code

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -105,7 +105,7 @@ const siteConfig = {
   ogImage: "img/logo@2x.png",
   twitterImage: "img/logo@2x.png",
 
-  gaTrackingId: "UA-44704216-8",
+  gaTrackingId: "UA-44704216-5",
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo"s URL...


### PR DESCRIPTION
Resolves NA
Impact: **minor**
Type: **bugfix**

## Issue
Documentation site hasn't been included in our analytic reporting, it looked like it just had the wrong GA code in the site config.

## Solution & Screenshots
Updated site config to the correct GA code

## Breaking changes
none

## Testing
Change will need to be deployed before we can verify GA is tracking the docs site.