### PR TITLE
bugfix: corrected new logo size

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -313,6 +313,7 @@
 
   .fixedHeaderContainer header img {
     height: auto;
+    max-width: 250px;
   }
 
   .headerWrapper header a:first-child {


### PR DESCRIPTION
Resolves #issueNumber
Impact: **minor**
Type: **bugfix**

## Issue
The new logo isn't fitting on the page correctly in Chrome.

## Solution & Screenshots
![logo-size](https://user-images.githubusercontent.com/1135948/89045671-e4884380-d319-11ea-8fca-39101105da15.png)

Set a `max-width` on the img tag so it wont look wonky on desktop in Chrome

![fixed-logo](https://user-images.githubusercontent.com/1135948/89045783-19949600-d31a-11ea-87a1-32fa4c2217ca.png)

## Testing
1. Verify the logo looks correct in Chrome and Firefox