### PR TITLE
docs: add note regarding guided tutorial for Reaction on Digital Ocean

### DIFF
--- a/public-docs/deploying.md
+++ b/public-docs/deploying.md
@@ -5,6 +5,12 @@ title: Deploying
 
 Reaction is an open source multi-service platform. All services are either publicly available Docker images on DockerHub or are Git repositories that include a `Dockerfile` so that you can build your own Docker image after customizing the service. This means that you can deploy the Reaction system on any infrastructure that supports running a Docker container cluster with a shared network.
 
+## Deploy Reaction on Digital Ocean
+
+The following guide is intended for users that are in the evaluation phase of Reaction Commerce. It is not meant to be a production grade deployment, rather a simple guided tutorial that will provide insight on how the platform works together. With that said, the concepts covered in the guided can be used to build a production grade deployment.
+
+[https://github.com/reactioncommerce/proxy-traefik](https://github.com/reactioncommerce/proxy-traefik)
+
 ## Docker Images
 
 You can find the published Reaction images [on our DockerHub page](https://hub.docker.com/u/reactioncommerce).

--- a/website/versioned_docs/version-2.9.1/intro-glance.md
+++ b/website/versioned_docs/version-2.9.1/intro-glance.md
@@ -66,6 +66,12 @@ The best option depends on your budget and your expected level of traffic. Below
 - Azure
 - Digital Ocean
 
+## Deploy Reaction on Digital Ocean
+
+The following guide is intended for users that are in the evaluation phase of Reaction Commerce. It is not meant to be a production grade deployment, rather a simple guided tutorial that will provide insight on how the platform works together. With that said, the concepts covered in the guided can be used to build a production grade deployment.
+
+[https://github.com/reactioncommerce/proxy-traefik](https://github.com/reactioncommerce/proxy-traefik)
+
 ## Who Uses Reaction?
 
 Ecommerce and marketplace sites from around the world are using Reaction in production now. Check out our [Community Showcase](https://docs.reactioncommerce.com/reaction-docs/trunk/community-showcase).


### PR DESCRIPTION
Resolves https://github.com/reactioncommerce/proxy-traefik/issues/3
Impact: **minor**
Type: **docs**

## Issue
There is no link to the guided deployment guide for deploying Reaction on Digital Ocean

## Solution & Screenshots
Adds note and link regarding the deployment guide.
