### PR TITLE
Update code-of-conduct.md

### DIFF
--- a/public-docs/code-of-conduct.md
+++ b/public-docs/code-of-conduct.md
@@ -13,7 +13,7 @@ This isn’t an exhaustive list of things that you can’t do. Rather, take it i
 
 This code of conduct applies to all spaces managed by Reaction Commerce. This includes our [development chat room](https://gitter.im/reactioncommerce/reaction), [forums](https://forums.reactioncommerce.com), [blog](https://blog.reactioncommerce.com), mailing lists, [issue tracker](https://github.com/reactioncommerce/reaction/issues), Reaction events and meetups, and any other forums or service created by the core project team which the community uses for communication. In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing <mailto:conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](reporting-guide.md).
+If you believe someone is violating the code of conduct, we ask that you report it by emailing <conduct@reactioncommerce.com>. For more details, please see our [Reporting Guidelines](reporting-guide.md).
 
 - **Be friendly and patient.**
 


### PR DESCRIPTION
Removed "mailto:" from markdown urls to stop them from appearing in the live links